### PR TITLE
config: add unsafe-eval and unsafe-inline headers

### DIFF
--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -68,7 +68,7 @@ APP_DEFAULT_SECURE_HEADERS = {
     'strict_transport_security_max_age': 31556926,  # One year in seconds
     'strict_transport_security_include_subdomains': True,
     'content_security_policy': {
-        'default-src': '\'self\'',
+        'default-src': '\'self\' \'unsafe-eval\'',
     },
     'content_security_policy_report_uri': None,
     'content_security_policy_report_only': False,


### PR DESCRIPTION
* Since Angular v1 uses eval and inline CSS by design, the
  corresponding CSP flags need to be set otherwise either the browser,
  if it supports CSP, or Angular itself, will block the execution of
  directives such as `ng-show` or `ng-hide` among others, preventing
  invenio to correctly render.
  (closes inveniosoftware/invenio-app-ils#21)

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>