### PR TITLE
config: CSP object-src and unsafe-inline

### DIFF
--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -58,7 +58,8 @@ APP_DEFAULT_SECURE_HEADERS = {
     'strict_transport_security_max_age': 31556926,  # One year in seconds
     'strict_transport_security_include_subdomains': True,
     'content_security_policy': {
-        'default-src': '\'self\'',
+        'default-src': ["'self'"],
+        'object-src': ["'none'"]
     },
     'content_security_policy_report_uri': None,
     'content_security_policy_report_only': False,

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -56,6 +56,11 @@ class InvenioApp(object):
         :param app: An instance of :class:`~flask.Flask`.
         """
         config_apps = ['APP_', 'RATELIMIT_']
+        flask_talisman_debug_mode = ["'unsafe-inline'"]
         for k in dir(config):
             if any([k.startswith(prefix) for prefix in config_apps]):
                 app.config.setdefault(k, getattr(config, k))
+        if app.config['DEBUG']:
+            app.config['APP_DEFAULT_SECURE_HEADERS'][
+                'content_security_policy']['default-src'] += \
+                flask_talisman_debug_mode


### PR DESCRIPTION
* ADD object-src: 'none' as suggested by the CSP evaluator tool,
  and default-src: 'unsafe-inline' to allow the use of
  Flask-DebugToolbar, the latter should be removed in production
  deployments.

Addresses https://github.com/inveniosoftware/cookiecutter-invenio-instance/issues/60

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>