### PR TITLE
Add feature: Health check via blueprint, default is a ping endpoint

### DIFF
--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -112,3 +112,7 @@ In addition to this configuration variable, you should make sure that your
 web server does not route requests to the application with an invalid Host
 header.
 """
+
+APP_HEALTH_BLUEPRINT_ENABLED = True
+"""Enable the ping (healthcheck) blueprint. (Default: ``False``)
+"""

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -10,10 +10,14 @@
 
 from __future__ import absolute_import, print_function
 
+import logging
+
 import pkg_resources
+from flask import Blueprint
 from flask_limiter import Limiter
 from flask_limiter.util import get_ipaddr
 from flask_talisman import Talisman
+from werkzeug.utils import import_string
 
 from . import config
 
@@ -47,6 +51,19 @@ class InvenioApp(object):
             self.talisman = Talisman(
                 app, **app.config.get('APP_DEFAULT_SECURE_HEADERS', {})
             )
+        # Enable PING view
+        if app.config['APP_HEALTH_BLUEPRINT_ENABLED']:
+            blueprint = Blueprint('invenio_app_ping', __name__)
+
+            @blueprint.route('/ping')
+            def ping():
+                """Load balancer ping view."""
+                return 'OK'
+
+            ping.talisman_view_options = {'force_https': False}
+
+            app.register_blueprint(blueprint)
+
         # Register self
         app.extensions['invenio-app'] = self
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -98,3 +98,12 @@ def test_empty_csp_when_set_empty(app):
     app.config['APP_DEFAULT_SECURE_HEADERS']['content_security_policy'] = {}
     expect = None
     _test_csp_default_src(app, expect)
+
+
+def test_default_health_blueprint(app):
+    app.config['APP_HEALTH_BLUEPRINT_ENABLED'] = True
+    # Initialize the app
+    InvenioApp(app)
+    with app.test_client() as client:
+        res = client.get('/ping')
+        assert res.status_code == 200


### PR DESCRIPTION
PR to solve https://github.com/inveniosoftware/invenio-app/issues/35

Two configuration variables are added:

- ``APP_HEALTH_BLUEPRINT_ENABLED`` to allow the user to enable the health checks.
- ``APP_HEALTH_BLUEPRINT`` to provide the import path to the function that creates the blueprint. This would allow more than one route for more than one check (e.g. uwsgi ping, elasticsearch ping, db ping).

By default (if enabled) there is only one route (``/ping``) that returns a 200.

A test has been provided for the default blueprint. A custom one has been tested, however, adding a test for a custom one would mean adding a views file.