### PR TITLE
ext: setting request_id in global vars

### DIFF
--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -116,3 +116,21 @@ header.
 APP_HEALTH_BLUEPRINT_ENABLED = True
 """Enable the ping (healthcheck) blueprint. (Default: ``False``)
 """
+
+APP_REQUESTID_HEADER = "X-Request-Id"
+"""Name of header containing a request id (max length 200 characters).
+
+If set, the request id will be extracted from the header and set on the global
+Flask ``g`` request object. The extracted request id can be used by other
+Invenio modules - e.g. Invenio-Logging could include it in log messages.
+
+The request id can be used to trace requests between systems to make
+troubleshooting easier.
+
+You can configure Nginx 1.10+ to automatically generate a request id and
+add it as a header to both the upstream WSGI server and downstream client::
+
+    add_header X-Request-ID $request_id;
+
+Set to ``None`` to not extract a request id.
+"""

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, print_function
 import logging
 
 import pkg_resources
-from flask import Blueprint
+from flask import Blueprint, g, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_ipaddr
 from flask_talisman import Talisman
@@ -63,6 +63,17 @@ class InvenioApp(object):
             ping.talisman_view_options = {'force_https': False}
 
             app.register_blueprint(blueprint)
+
+        requestid_header = app.config.get('APP_REQUESTID_HEADER')
+        if requestid_header:
+            @app.before_request
+            def set_request_id():
+                """Extracts a request id from an HTTP header."""
+                request_id = request.headers.get(requestid_header)
+                if request_id:
+                    # Capped at 200 to protect against malicious clients
+                    # sending very large headers.
+                    g.request_id = request_id[:200]
 
         # Register self
         app.extensions['invenio-app'] = self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,12 @@ def base_app():
     )
     app_.config['APP_DEFAULT_SECURE_HEADERS'] = APP_DEFAULT_SECURE_HEADERS
     app_.config['APP_DEFAULT_SECURE_HEADERS']['force_https'] = False
+
+    @app_.route('/requestid')
+    def requestid():
+        from flask import g  # Prevent pytest problems
+        return g.request_id if g and hasattr(g, 'request_id') else ''
+
     return app_
 
 


### PR DESCRIPTION
* Adding a before_request function that extracts the header
  X-Request-Id and sets in the global flask request variable.
  Closes #38

Co-Authored-By: Alexander Ioannidis <a.ioannidis@cern.ch>