### PR TITLE
tests: remove python 2 support to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: REQUIREMENTS=devel
+    - python: "3.8"
 
 cache:
   - pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,13 @@ cache:
 
 env:
   - REQUIREMENTS=lowest
-  - REQUIREMENTS=release DEPLOY=true
+  - REQUIREMENTS=release
   - REQUIREMENTS=devel
 
 python:
-  - "2.7"
-  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 
 before_install:
   - "nvm install 6; nvm use 6"
@@ -56,6 +57,4 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: "3.5"
-    repo: inveniosoftware/invenio-app
-    condition: $DEPLOY = true
+  skip_existing: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@
 Changes
 =======
 
+Version 1.3.0 (released to-be-determined)
+
+- Removed support for Python 2
+- Removed support for Python 3.5
+- Added support for Python 3.6, 3.7, 3.8
+
 Version 1.2.4 (released 2019-11-20)
 
 - Disable ratelimit for celery.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,11 +8,11 @@
 Changes
 =======
 
-Version 1.3.0 (released to-be-determined)
+Version 1.2.6 (released 2020-05-06)
 
-- Removed support for Python 2
-- Removed support for Python 3.5
-- Added support for Python 3.6, 3.7, 3.8
+- Deprecated Python versions lower than 3.6.0. Now supporting 3.6.0 and 3.7.0.
+
+Version 1.2.5 (released 2020-02-26)
 
 Version 1.2.4 (released 2019-11-20)
 

--- a/invenio_app/version.py
+++ b/invenio_app/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.2.5'
+__version__ = '1.2.6'

--- a/setup.py
+++ b/setup.py
@@ -99,10 +99,10 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Development Status :: 5 - Production/Stable',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ install_requires = [
     'invenio-base>=1.1.0',
     'invenio-cache>=1.0.0',
     'invenio-config>=1.0.0',
+    'six>=1.12.0',
     'uritools>=1.0.1',
 ]
 
@@ -102,7 +103,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Development Status :: 5 - Production/Stable',
     ],
 )


### PR DESCRIPTION
- pinned `six>=1.12.0` related [codimd](https://codimd.web.cern.ch/lFwbR-zWRHiB6SnDF1imZg?both#DETECTED-ISSUES)
- child of inveniosoftware/invenio#4004
- closes #63