### PR TITLE
global: add HEAD and OPTIONS verbs to ping

### DIFF
--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -69,7 +69,7 @@ class InvenioApp(object):
             blueprint = Blueprint('invenio_app_ping', __name__)
             limiter = self.limiter
 
-            @blueprint.route('/ping')
+            @blueprint.route('/ping', methods=['HEAD', 'OPTIONS', 'GET'])
             @limiter.exempt
             def ping():
                 """Load balancer ping view."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -128,6 +128,10 @@ def test_ping_exempt_from_rate_limiting(app_with_no_limiter):
         assert res.status_code == 200
         res = client.get('/ping')
         assert res.status_code == 200
+        res = client.head('/ping')
+        assert res.status_code == 200
+        res = client.options('/ping')
+        assert res.status_code == 200
 
 
 def test_requestid(base_app):


### PR DESCRIPTION
* adds HEAD and OPTIONS HTTP verbs to the /ping endpoint as recommended
  in HAProxy documentation