### PR TITLE
global: add HEAD and OPTIONS verbs to ping

### DIFF
--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -69,7 +69,7 @@ class InvenioApp(object):
             blueprint = Blueprint('invenio_app_ping', __name__)
             limiter = self.limiter
 
-            @blueprint.route('/ping')
+            @blueprint.route('/ping', methods=['HEAD', 'OPTIONS', 'GET'])
             @limiter.exempt
             def ping():
                 """Load balancer ping view."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@
 [pytest]
 pep8ignore = docs/conf.py ALL
 addopts = --pep8 --doctest-glob="*.rst" --doctest-modules --cov=invenio_app --cov-report=term-missing
+filterwarnings = ignore::pytest.PytestDeprecationWarning

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,7 +10,7 @@
 export PYTEST_ADDOPTS='docs tests invenio_app'
 
 pydocstyle invenio_app tests docs && \
-isort -rc -c -df && \
+isort invenio_app tests --check-only --diff && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,8 +86,8 @@ def app(base_app):
 @pytest.fixture()
 def wsgi_apps():
     """Wsgi app fixture."""
-    from invenio_base.wsgi import create_wsgi_factory, wsgi_proxyfix
     from invenio_base.app import create_app_factory
+    from invenio_base.wsgi import create_wsgi_factory, wsgi_proxyfix
 
     def _config(app, **kwargs):
         app.config.update(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -128,6 +128,10 @@ def test_ping_exempt_from_rate_limiting(app_with_no_limiter):
         assert res.status_code == 200
         res = client.get('/ping')
         assert res.status_code == 200
+        res = client.head('/ping')
+        assert res.status_code == 200
+        res = client.options('/ping')
+        assert res.status_code == 200
 
 
 def test_requestid(base_app):


### PR DESCRIPTION
* adds HEAD and OPTIONS HTTP verbs to the /ping endpoint as recommended
  in HAProxy documentation