### PR TITLE
Allow newer versions of Flask-Talisman

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors
 - Nikos Filippakis
 - Rémi Ducceschi
 - Tibor Simko
+- Maximilian Moser

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2021      TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -40,7 +41,7 @@ install_requires = [
     'flask-celeryext>=0.2.2',
     'flask-limiter>=1.0.1,<1.2.0',
     'flask-shell-ipython>=0.3.1',
-    'flask-talisman>=0.3.2,<0.5.1',
+    'flask-talisman>=0.3.2,<1.0',
     'invenio-base>=1.2.3',
     'invenio-cache>=1.0.0',
     'invenio-config>=1.0.0',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,7 +55,6 @@ def test_headers(app_with_no_limiter):
 
         res = client.get('/avengers')
         assert res.status_code == 429
-        assert res.headers['X-Content-Security-Policy']
         assert res.headers['X-Content-Type-Options']
         assert res.headers['X-Frame-Options']
         assert res.headers['X-XSS-Protection']
@@ -82,9 +81,6 @@ def _test_csp_default_src(app, expect):
         assert res.status_code == 200
         assert _normalize_csp_header(
             res.headers.get('Content-Security-Policy')
-        ) == _normalize_csp_header(expect)
-        assert _normalize_csp_header(
-            res.headers.get('X-Content-Security-Policy')
         ) == _normalize_csp_header(expect)
 
 


### PR DESCRIPTION
Allow newer versions of `Flask-Talisman` and adapt the tests to the changes in 0.8.0 (i.e. removal of the `X-Content-Security-Policy` header).

The `X-Content-Security-Policy` HTTP header was deprecated in favor of the standardized `Content-Security-Policy` header and it is recommended against adding it alongside with the standardized version: https://content-security-policy.com/
The only "modern" browser that doesn't support the standardized header is IE, which only supports the `sandbox` directive anyway, however: https://stackoverflow.com/questions/42937146/content-security-policy-does-not-work-in-internet-explorer-11