### PR TITLE
installation: bump modules to support python v3.12

### DIFF
--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -36,7 +36,7 @@ traffic, you can replace it with another one from the following
 RATELIMIT_HEADERS_ENABLED = True
 """Enable rate limit headers. (Default: ``True``)"""
 
-RATELIMIT_STORAGE_URL = "memory://"
+RATELIMIT_STORAGE_URI = "memory://"
 """Storage backend to store rate-limiting information.
 
     Memory is used by default if no value is provided.

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -9,6 +9,8 @@
 
 """Invenio app extension."""
 
+import warnings
+
 from flask import Blueprint, g, request
 from flask_limiter import Limiter
 from flask_talisman import Talisman
@@ -116,6 +118,14 @@ class InvenioApp(object):
 
         :param app: An instance of :class:`~flask.Flask`.
         """
+        # RATELIMIT_STORAGE_URL was deprecated in 2.0 and removed in 3.0
+        if "RATELIMIT_STORAGE_URL" in app.config:
+            app.config["RATELIMIT_STORAGE_URI"] = app.config["RATELIMIT_STORAGE_URI"]
+            warnings.warn(
+                "RATELIMIT_STORAGE_URL has been renamed to RATELIMIT_STORAGE_URI.",
+                DeprecationWarning,
+            )
+
         config_apps = ["APP_", "RATELIMIT_"]
         flask_talisman_debug_mode = "'unsafe-inline'"
         for k in dir(config):

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -120,7 +120,7 @@ class InvenioApp(object):
         """
         # RATELIMIT_STORAGE_URL was deprecated in 2.0 and removed in 3.0
         if "RATELIMIT_STORAGE_URL" in app.config:
-            app.config["RATELIMIT_STORAGE_URI"] = app.config["RATELIMIT_STORAGE_URI"]
+            app.config["RATELIMIT_STORAGE_URI"] = app.config["RATELIMIT_STORAGE_URL"]
             warnings.warn(
                 "RATELIMIT_STORAGE_URL has been renamed to RATELIMIT_STORAGE_URI.",
                 DeprecationWarning,

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,14 +28,13 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    flask-limiter>=1.0.1,<1.2.0
+    flask-limiter>=2,<3
     flask-shell-ipython>=0.3.1
     flask-talisman>=0.3.2,<1.0
     invenio-base>=1.3.0
     invenio-cache>=1.1.0
     invenio-celery>=1.2.4
     invenio-config>=1.0.0
-    limits>=1.5.1,<2.0
     uritools>=1.0.1
 
 [options.extras_require]
@@ -43,7 +42,7 @@ tests =
     pytest-black>=0.3.0
     pytest-invenio>=1.4.7
     mock>=4.0.0
-    sphinx>=4.2.0,<5
+    sphinx>=5.0,<6
 
 [options.entry_points]
 console_scripts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@
 
 """Pytest configuration."""
 
-import imp
 import sys
+import types
 from collections import namedtuple
 from copy import deepcopy
 
@@ -123,7 +123,7 @@ def create_mocked_flask_security_with_user_init():
     def mocked_flask_security(user):
         """Add mocked flask-security."""
         module_name = "flask_security"
-        test_api_module = imp.new_module(module_name)
+        test_api_module = types.ModuleType(module_name)
         test_api_module.current_user = namedtuple("User", user.keys())(*user.values())
         sys.modules[module_name] = test_api_module
         return test_api_module


### PR DESCRIPTION
* Bumps Flask-Limitier to v2.x. Note that v3 which is already out requires more work to be upgrade. Fixes deprecated RATELIMIT_STORAGE_URL variable.

* Removes use of deprecated imp module in tests.

