### PR TITLE
cli: add RPCServer commands

### DIFF
--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -2,15 +2,132 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """CLI application for Invenio flavours."""
 
+import contextlib
+import io
+import socket
+import socketserver
+from pickle import dumps, loads
+
+from click import group, option, pass_context, secho
+from flask.cli import with_appcontext
 from invenio_base.app import create_cli
 
 from .factory import create_app
 
 #: Invenio CLI application.
 cli = create_cli(create_app=create_app)
+
+
+class RPCRequestHandler(socketserver.BaseRequestHandler):
+    """RPCRequestHandler."""
+
+    def handle(self):
+        """Handles the requests to the RPCServer."""
+        data = self.request.recv(4096)
+
+        if not data:
+            return
+
+        try:
+            command_parts = loads(data)
+
+            if not isinstance(command_parts, list) or len(command_parts) == 0:
+                raise ValueError("Invalid command format should be a list.")
+
+            if command_parts[0] == "ping":
+                result = "pong"
+            else:
+                output_buffer = io.StringIO()
+                with contextlib.redirect_stdout(output_buffer):
+                    cli.main(args=command_parts, standalone_mode=False)
+                result = output_buffer.getvalue().strip()
+
+            response = {"success": True, "result": result}
+        except Exception as e:
+            response = {"success": False, "error": str(e)}
+
+        self.request.sendall(dumps(response))
+
+
+class RPCServer(socketserver.TCPServer):
+    """RPCServer implementation."""
+
+    allow_reuse_address = True
+
+    def shutdown_server(self):
+        """Shutdown the server."""
+        secho("Shutting down RPC Server...", fg="green")
+        self.shutdown()
+        self.server_close()
+
+
+def send(host, port, args):
+    """Send."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((host, port))
+        s.sendall(dumps(list(args)))
+        return loads(s.recv(16384))
+
+
+@group()
+def rpc_server():
+    """RPC server."""
+
+
+@rpc_server.command("start")
+@option("--port", default=5000)
+@option("--host", default="localhost")
+@with_appcontext
+def rpc_server_start(port, host):
+    """Start rpc server."""
+    server = RPCServer((host, port), RPCRequestHandler)
+
+    secho(
+        f"RPC Server is running on port {host}:{port}... (Press Ctrl+C to stop)",
+        fg="green",
+    )
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+@rpc_server.command(
+    "send",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+@option("--port", default=5000)
+@option("--host", default="localhost")
+@option("--plain", is_flag=True, default=False)
+@pass_context
+def rpc_server_send(ctx, port, host, plain):
+    """Send."""
+    response = send(host, port, ctx.args)
+
+    if response["success"]:
+        prefix = "" if plain else "Response: "
+        color = "green"
+        message = response["result"]
+    else:
+        prefix = "" if plain else "Error: "
+        color = "red"
+        message = response["error"]
+
+    secho(f"{prefix}{message}", fg=color)
+
+
+@rpc_server.command("ping")
+@option("--port", default=5000)
+@option("--host", default="localhost")
+def rpc_server_ping(port, host):
+    """Ping."""
+    response = send(host, port, ["ping"])
+    secho(response["result"])

--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -206,3 +206,6 @@ add it as a header to both the upstream WSGI server and downstream client::
 
 Set to ``None`` to not extract a request id.
 """
+
+FLASK_DEBUGTOOLBAR_ENABLED = True
+"""Make it possible to disable the warning."""

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2026 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2026 Graz University of Technology.
 # Copyright (C) 2026 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
@@ -173,7 +173,8 @@ class InvenioApp(object):
 
             app.extensions["flask-debugtoolbar"] = DebugToolbarExtension(app)
         except ImportError:
-            app.logger.debug("Flask-DebugToolbar extension not installed.")
+            if app.config["FLASK_DEBUGTOOLBAR_ENABLED"]:
+                app.logger.debug("Flask-DebugToolbar extension not installed.")
 
         # Add theme template loader
         if app.config.get("APP_THEME"):
@@ -195,7 +196,7 @@ class InvenioApp(object):
                 DeprecationWarning,
             )
 
-        config_apps = ["APP_", "RATELIMIT_"]
+        config_apps = ["APP_", "RATELIMIT_", "FLASK_"]
         flask_talisman_debug_mode = "'unsafe-inline'"
         for k in dir(config):
             if any([k.startswith(prefix) for prefix in config_apps]):

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,9 @@ tests =
 [options.entry_points]
 console_scripts =
     invenio = invenio_app.cli:cli
+    rpc-server = invenio_app.cli:rpc_server
+flask.commands =
+    rpc-server = invenio_app.cli:rpc_server
 invenio_base.api_apps =
     invenio_app = invenio_app:InvenioApp
 invenio_base.apps =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2026 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -66,6 +66,7 @@ def app(base_app):
         RATELIMIT_AUTHENTICATED_USER="5 per second",
         RATELIMIT_PER_ENDPOINT={"unlimited_rate": "200 per second"},
         RATELIMIT_HEADERS_ENABLED=True,
+        RATELIMIT_STORAGE_URI="memory://",
     )
     Limiter(
         base_app,

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -2,15 +2,19 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Celery test."""
 
+import os
+
 
 def test_celery():
     """Test celery application."""
+    os.environ["INVENIO_SECRET_KEY"] = "CHANGE_ME"
     from invenio_app.celery import celery
 
     celery.loader.import_default_modules()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,8 +14,10 @@ import importlib.metadata
 from click.testing import CliRunner
 
 
-def test_basic_cli():
+def test_basic_cli(app_config):
     """Test version import."""
+    app_config["SECRET_KEY"] = "CHANGE_ME"
+
     from invenio_app.cli import cli
 
     res = CliRunner().invoke(cli)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2019 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -23,7 +23,7 @@ def test_version():
 
 def test_config_loader():
     """Test config loader."""
-    app = create_ui()
+    app = create_ui(SECRET_KEY="CHANGE_ME")
     assert app.jinja_env.cache_size == 1000
 
 
@@ -33,6 +33,7 @@ def test_trusted_hosts():
         TRUSTED_HOSTS=["example.org", "www.example.org"],
         APP_ENABLE_SECURE_HEADERS=False,
         RATELIMIT_ENABLED=False,
+        SECRET_KEY="CHANGE_ME",
     )
 
     @app.route("/host")

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -46,7 +47,7 @@ def blueprint():
 @pytest.fixture()
 def notheme_app(instance_path, blueprint):
     """Application without template theming."""
-    app = create_ui()
+    app = create_ui(SECRET_KEY="CHANGE_ME")
     app.register_blueprint(blueprint)
     with app.app_context():
         yield app
@@ -55,7 +56,10 @@ def notheme_app(instance_path, blueprint):
 @pytest.fixture()
 def theme_app(instance_path, blueprint):
     """Application with template theming."""
-    app = create_ui(APP_THEME=["semantic-ui", "bootstrap3"])
+    app = create_ui(
+        APP_THEME=["semantic-ui", "bootstrap3"],
+        SECRET_KEY="CHANGE_ME",
+    )
     app.register_blueprint(blueprint)
     with app.app_context():
         yield app


### PR DESCRIPTION
### how to use

to use it start the rpc server by
```
invenio rpc-server start
```

send to the rpc-server by:
```
rpc-server send webpack create
```

### what is working:
- `rpc-server send webpack clean` no parameters
- `rpc-server send collect --verbose` flag parameters
- `rpc-server send access allow-action-for-role --action superuser-access --role administration` parameters
- `rpc-server send access allow administration-moderation role administration-moderation` chained calls

### invenio-cli
- invenio-cli has to start the rpc-server within the `.venv` of `my-site`. e.g `uv run invenio rpc-server start`, naturally this has to be started in the background. maybe with a customizable host:port configuration, to have multiple invenio rpc-servers arround
- to be used it should be enough to do something like `uv run rpc-server send webpack create`. `rpc-server` does not start a flask-app and should be fast.
- should the rpc-server be started in a separate shell to provide the error log?
- should invenio-cli start the server on every call? (performance wise, NOT)

### open TODO's
- make host:port configurable!


### NOTE
- to remove all warnings this has been merged: https://github.com/inveniosoftware/invenio-cache/pull/33