### PR TITLE
Improve Flask-Talisman ergonomics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,11 +9,6 @@
 
 """Sphinx configuration."""
 
-import os
-import sys
-
-import sphinx.environment
-
 from invenio_app import __version__
 
 # -- General configuration ------------------------------------------------

--- a/invenio_app/__init__.py
+++ b/invenio_app/__init__.py
@@ -168,12 +168,13 @@ better to provide them via an installabled Python package. Do take care not
 to overwrite any existing Invenio files.
 """
 
-from .ext import InvenioApp, talisman
+from .ext import InvenioApp, limiter, talisman
 
 __version__ = "3.0.0"
 
 __all__ = (
     "__version__",
     "InvenioApp",
+    "limiter",
     "talisman",
 )

--- a/invenio_app/__init__.py
+++ b/invenio_app/__init__.py
@@ -168,11 +168,12 @@ better to provide them via an installabled Python package. Do take care not
 to overwrite any existing Invenio files.
 """
 
-from .ext import InvenioApp
+from .ext import InvenioApp, talisman
 
 __version__ = "3.0.0"
 
 __all__ = (
     "__version__",
     "InvenioApp",
+    "talisman",
 )

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -13,7 +13,6 @@ import warnings
 
 from flask import Blueprint, g, request
 from flask_limiter import Limiter
-from flask_talisman import Talisman
 
 from invenio_app.limiter import useragent_and_ip_limit_key
 

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -3,6 +3,7 @@
 # This file is part of Invenio.
 # Copyright (C) 2017-2019 CERN.
 # Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2026 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,11 +14,48 @@ import warnings
 
 from flask import Blueprint, g, request
 from flask_limiter import Limiter
+from flask_talisman import Talisman as TalismanClass
 
 from invenio_app.limiter import useragent_and_ip_limit_key
 
 from . import config
 from .helpers import ThemeJinjaLoader, obj_or_import_string, safe_redirect
+
+talisman = TalismanClass()
+"""Shared instance of the ``Flask-Talisman`` extension.
+
+This ``Talisman`` instance gets registered as part of the ``Invenio-App``
+extension initialization.
+
+For example, it can be used to set custom CSP headers for a new view function:
+
+.. code-block:: python
+
+    from invenio_app import talisman
+
+    @talisman(content_security_policy={})
+    @app.route("/")
+    def load_some_script():
+        return '<script src="https://example.org/myscript.js"></script>'
+
+
+As another example, it can also be used to override the CSP header values for
+an existing view function, as part of a function that is registered in the
+``invenio_base.finalize_app`` entrypoint group:
+
+.. code-block:: python
+
+    from invenio_app import talisman
+
+    def finalize_app(app):
+        "Remove the CSP header only for the 'profiler.report_view' endpoint."
+        orig_profiler_report_view = app.view_functions["profiler.report_view"]
+
+        @app.endpoint("profiler.report_view")
+        @talisman(content_security_policy={})
+        def wrapped_profiler_report_view(*args, **kwargs):
+            return orig_profiler_report_view(*args, **kwargs)
+"""
 
 
 class InvenioApp(object):
@@ -45,7 +83,8 @@ class InvenioApp(object):
 
         # Enable secure HTTP headers
         if app.config["APP_ENABLE_SECURE_HEADERS"]:
-            self.talisman = Talisman(
+            self.talisman = talisman
+            self.talisman.init_app(
                 app, **app.config.get("APP_DEFAULT_SECURE_HEADERS", {})
             )
 

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -12,14 +12,23 @@
 
 import warnings
 
-from flask import Blueprint, g, request
-from flask_limiter import Limiter
+from flask import Blueprint, current_app, g, request
+from flask_limiter import Limiter as LimiterClass
 from flask_talisman import Talisman as TalismanClass
+from werkzeug.local import LocalProxy
 
 from invenio_app.limiter import useragent_and_ip_limit_key
 
 from . import config
 from .helpers import ThemeJinjaLoader, obj_or_import_string, safe_redirect
+
+_ratelimit_key_func = LocalProxy(
+    lambda: obj_or_import_string(
+        current_app.config.get("RATELIMIT_KEY_FUNC"),
+        default=useragent_and_ip_limit_key,
+    )
+)
+
 
 talisman = TalismanClass()
 """Shared instance of the ``Flask-Talisman`` extension.
@@ -55,6 +64,41 @@ an existing view function, as part of a function that is registered in the
         @talisman(content_security_policy={})
         def wrapped_profiler_report_view(*args, **kwargs):
             return orig_profiler_report_view(*args, **kwargs)
+"""
+
+
+limiter = LimiterClass(key_func=_ratelimit_key_func)
+"""Shared instance of the ``Flask-Limiter`` extension.
+
+This ``Limiter`` instance gets registered as part of the ``Invenio-App``
+extension initialization.
+
+For example, it can be used to set a custom limit for a new view function:
+
+.. code-block:: python
+
+    import random
+    from invenio_app import limiter
+
+    @app.route("/daily-fortune")
+    @limiter.limit("1/day")
+    def lucky_d6():
+        return random.randint(1, 6)
+
+
+If that fails with ``RuntimeError: Working outside of application context.``,
+use the ``app.app_context()`` context manager around the ``limiter`` usage:
+
+.. code-block:: python
+
+    import random
+    from invenio_app import limiter
+
+    with app.app_context():
+        @app.route("/daily-fortune")
+        @limiter.limit("1/day")
+        def lucky_d6():
+            return random.randint(1, 6)
 """
 
 
@@ -94,20 +138,15 @@ class InvenioApp(object):
         # Flask limiter needs to be initialised after talisman, since if the
         # talisman preprocessor doesn't run you will get an error on it's
         # afterprocessor.
-        self.limiter = Limiter(
-            app,
-            key_func=obj_or_import_string(
-                app.config.get("RATELIMIT_KEY_FUNC"), default=useragent_and_ip_limit_key
-            ),
-        )
+        self.limiter = limiter
+        self.limiter.init_app(app)
 
         # Enable PING view
         if app.config["APP_HEALTH_BLUEPRINT_ENABLED"]:
             blueprint = Blueprint("invenio_app_ping", __name__)
-            limiter = self.limiter
 
             @blueprint.route("/ping", methods=["HEAD", "OPTIONS", "GET"])
-            @limiter.exempt
+            @self.limiter.exempt
             def ping():
                 """Load balancer ping view."""
                 return "OK"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     flask>=3.1.0
-    flask-limiter>=2,<3
+    flask-limiter>=4,<5
     flask-shell-ipython>=0.3.1
     flask-talisman>=0.3.2,<1.0
     invenio-base>=2.2.0,<3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,6 @@
 
 """Pytest configuration."""
 
-import sys
-import types
-from collections import namedtuple
 from copy import deepcopy
 
 import pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -66,7 +66,7 @@ def _normalize_csp_header(header):
 
 def _test_csp_default_src(app, expect):
     """Assert that the Content-Security-Policy header is the expect param."""
-    ext = InvenioApp(app)
+    InvenioApp(app)
 
     @app.route("/captain_america")
     def captain_america():


### PR DESCRIPTION
Closes #22 

This should make it easier to use the Flask-Talisman extension via the `finalize_app` entrypoints, e.g. to relax the CSP settings for individual endpoints.