### PR TITLE
fix(tests): flask-limiter constructor change

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def app(base_app):
         RATELIMIT_HEADERS_ENABLED=True,
     )
     Limiter(
-        base_app,
+        app=base_app,
         key_func=obj_or_import_string(
             base_app.config.get("RATELIMIT_KEY_FUNC"),
             default=useragent_and_ip_limit_key,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,15 +49,25 @@ def base_app():
     return app_
 
 
+@pytest.fixture(scope="module")
+def fresh_limiter_instance():
+    """Enforce a fresh limiter instance for test module."""
+    import invenio_app.ext
+
+    invenio_app.ext.limiter = invenio_app.ext.LimiterClass(
+        key_func=invenio_app.ext._ratelimit_key_func
+    )
+
+
 @pytest.fixture()
-def app_with_no_limiter(base_app):
+def app_with_no_limiter(base_app, fresh_limiter_instance):
     """Flask application fixture without limiter registered."""
     with base_app.app_context():
         yield base_app
 
 
 @pytest.fixture()
-def app(base_app):
+def app(base_app, fresh_limiter_instance):
     """Flask application fixture."""
     base_app.config.update(
         TRUSTED_HOSTS=["localhost"],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,45 +20,6 @@ def test_rate_secure_headers(app):
     assert "talisman" not in app.extensions
 
 
-def test_headers(app_with_no_limiter):
-    """Test headers."""
-    app_with_no_limiter.config["RATELIMIT_APPLICATION"] = "1/day"
-    ext = InvenioApp(app_with_no_limiter)
-
-    for handler in app_with_no_limiter.logger.handlers:
-        ext.limiter.logger.addHandler(handler)
-
-    @app_with_no_limiter.route("/jessica_jones")
-    def jessica_jones():
-        return "jessica jones"
-
-    @app_with_no_limiter.route("/avengers")
-    def avengers():
-        return "infinity war"
-
-    with app_with_no_limiter.test_client() as client:
-        res = client.get("/jessica_jones")
-        assert res.status_code == 200
-        assert res.headers["X-RateLimit-Limit"] == "1"
-        assert res.headers["X-RateLimit-Remaining"] == "0"
-        assert res.headers["X-RateLimit-Reset"]
-
-        res = client.get("/jessica_jones")
-        assert res.status_code == 429
-        assert res.headers["X-RateLimit-Limit"]
-        assert res.headers["X-RateLimit-Remaining"]
-        assert res.headers["X-RateLimit-Reset"]
-
-        res = client.get("/avengers")
-        assert res.status_code == 429
-        assert res.headers["X-Content-Type-Options"]
-        assert res.headers["X-Frame-Options"]
-        assert res.headers["X-XSS-Protection"]
-        assert res.headers["X-RateLimit-Limit"]
-        assert res.headers["X-RateLimit-Remaining"]
-        assert res.headers["X-RateLimit-Reset"]
-
-
 def _normalize_csp_header(header):
     """Normalize a CSP header for consistent comparisons."""
     return {p.strip() for p in (header or "").split(";")}

--- a/tests/test_app_no_limitter.py
+++ b/tests/test_app_no_limitter.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2026 CERN.
+# Copyright (C) 2022 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module tests.
+
+The tests in this module use ``app_with_no_limiter`` fixture.
+They need to be in a separate module from tests that use ``app`` fixture,
+because it modifies the config on a global ``base_app`` and create a Limiter
+instance that would influence these tests.
+"""
+
+from invenio_app import InvenioApp
+
+
+def test_headers(app_with_no_limiter):
+    """Test headers."""
+    app_with_no_limiter.config["RATELIMIT_APPLICATION"] = "1/day"
+    ext = InvenioApp(app_with_no_limiter)
+
+    for handler in app_with_no_limiter.logger.handlers:
+        ext.limiter.logger.addHandler(handler)
+
+    @app_with_no_limiter.route("/jessica_jones")
+    def jessica_jones():
+        return "jessica jones"
+
+    @app_with_no_limiter.route("/avengers")
+    def avengers():
+        return "infinity war"
+
+    with app_with_no_limiter.test_client() as client:
+        res = client.get("/jessica_jones")
+        assert res.status_code == 200
+        assert res.headers["X-RateLimit-Limit"] == "1"
+        assert res.headers["X-RateLimit-Remaining"] == "0"
+        assert res.headers["X-RateLimit-Reset"]
+
+        res = client.get("/jessica_jones")
+        assert res.status_code == 429
+        assert res.headers["X-RateLimit-Limit"]
+        assert res.headers["X-RateLimit-Remaining"]
+        assert res.headers["X-RateLimit-Reset"]
+
+        res = client.get("/avengers")
+        assert res.status_code == 429
+        assert res.headers["X-Content-Type-Options"]
+        assert res.headers["X-Frame-Options"]
+        assert res.headers["X-XSS-Protection"]
+        assert res.headers["X-RateLimit-Limit"]
+        assert res.headers["X-RateLimit-Remaining"]
+        assert res.headers["X-RateLimit-Reset"]


### PR DESCRIPTION
### Description

A recent release of `invenio-app` bumps `flask-limiter` from 3.x → 4.x. This brings API change for `Limiter`'s constructor - the `app` changed to keyword argument. This does not influence runtime (where `Limiter` is created without the app) but was not reflected in tests. This PR fixes that.

Additionally, `Limiter` started caching stuff, causing tests to influence one another. Fixed by splitting the tests and adding a new module-level fixture `fresh_limiter_instance`

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
