### PR TITLE
fix(installation): add Python 3.9-compatible Flask-Limiter version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,8 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     flask>=3.1.0
-    flask-limiter>=4,<5
+    flask-limiter>=3.11,<3.12; python_version < "3.10"
+    flask-limiter>=4,<5; python_version >= "3.10"
     flask-shell-ipython>=0.3.1
     flask-talisman>=0.3.2,<1.0
     invenio-base>=2.2.0,<3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def app(base_app):
         RATELIMIT_HEADERS_ENABLED=True,
     )
     Limiter(
-        base_app,
+        app=base_app,
         key_func=obj_or_import_string(
             base_app.config.get("RATELIMIT_KEY_FUNC"),
             default=useragent_and_ip_limit_key,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,15 +49,25 @@ def base_app():
     return app_
 
 
+@pytest.fixture(scope="module")
+def fresh_limiter_instance():
+    """Enforce a fresh limiter instance for test module."""
+    import invenio_app.ext
+
+    invenio_app.ext.limiter = invenio_app.ext.LimiterClass(
+        key_func=invenio_app.ext._ratelimit_key_func
+    )
+
+
 @pytest.fixture()
-def app_with_no_limiter(base_app):
+def app_with_no_limiter(base_app, fresh_limiter_instance):
     """Flask application fixture without limiter registered."""
     with base_app.app_context():
         yield base_app
 
 
 @pytest.fixture()
-def app(base_app):
+def app(base_app, fresh_limiter_instance):
     """Flask application fixture."""
     base_app.config.update(
         TRUSTED_HOSTS=["localhost"],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,45 +20,6 @@ def test_rate_secure_headers(app):
     assert "talisman" not in app.extensions
 
 
-def test_headers(app_with_no_limiter):
-    """Test headers."""
-    app_with_no_limiter.config["RATELIMIT_APPLICATION"] = "1/day"
-    ext = InvenioApp(app_with_no_limiter)
-
-    for handler in app_with_no_limiter.logger.handlers:
-        ext.limiter.logger.addHandler(handler)
-
-    @app_with_no_limiter.route("/jessica_jones")
-    def jessica_jones():
-        return "jessica jones"
-
-    @app_with_no_limiter.route("/avengers")
-    def avengers():
-        return "infinity war"
-
-    with app_with_no_limiter.test_client() as client:
-        res = client.get("/jessica_jones")
-        assert res.status_code == 200
-        assert res.headers["X-RateLimit-Limit"] == "1"
-        assert res.headers["X-RateLimit-Remaining"] == "0"
-        assert res.headers["X-RateLimit-Reset"]
-
-        res = client.get("/jessica_jones")
-        assert res.status_code == 429
-        assert res.headers["X-RateLimit-Limit"]
-        assert res.headers["X-RateLimit-Remaining"]
-        assert res.headers["X-RateLimit-Reset"]
-
-        res = client.get("/avengers")
-        assert res.status_code == 429
-        assert res.headers["X-Content-Type-Options"]
-        assert res.headers["X-Frame-Options"]
-        assert res.headers["X-XSS-Protection"]
-        assert res.headers["X-RateLimit-Limit"]
-        assert res.headers["X-RateLimit-Remaining"]
-        assert res.headers["X-RateLimit-Reset"]
-
-
 def _normalize_csp_header(header):
     """Normalize a CSP header for consistent comparisons."""
     return {p.strip() for p in (header or "").split(";")}

--- a/tests/test_app_no_limitter.py
+++ b/tests/test_app_no_limitter.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2026 CERN.
+# Copyright (C) 2022 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Module tests.
+
+The tests in this module use ``app_with_no_limiter`` fixture.
+They need to be in a separate module from tests that use ``app`` fixture,
+because it modifies the config on a global ``base_app`` and create a Limiter
+instance that would influence these tests.
+"""
+
+from invenio_app import InvenioApp
+
+
+def test_headers(app_with_no_limiter):
+    """Test headers."""
+    app_with_no_limiter.config["RATELIMIT_APPLICATION"] = "1/day"
+    ext = InvenioApp(app_with_no_limiter)
+
+    for handler in app_with_no_limiter.logger.handlers:
+        ext.limiter.logger.addHandler(handler)
+
+    @app_with_no_limiter.route("/jessica_jones")
+    def jessica_jones():
+        return "jessica jones"
+
+    @app_with_no_limiter.route("/avengers")
+    def avengers():
+        return "infinity war"
+
+    with app_with_no_limiter.test_client() as client:
+        res = client.get("/jessica_jones")
+        assert res.status_code == 200
+        assert res.headers["X-RateLimit-Limit"] == "1"
+        assert res.headers["X-RateLimit-Remaining"] == "0"
+        assert res.headers["X-RateLimit-Reset"]
+
+        res = client.get("/jessica_jones")
+        assert res.status_code == 429
+        assert res.headers["X-RateLimit-Limit"]
+        assert res.headers["X-RateLimit-Remaining"]
+        assert res.headers["X-RateLimit-Reset"]
+
+        res = client.get("/avengers")
+        assert res.status_code == 429
+        assert res.headers["X-Content-Type-Options"]
+        assert res.headers["X-Frame-Options"]
+        assert res.headers["X-XSS-Protection"]
+        assert res.headers["X-RateLimit-Limit"]
+        assert res.headers["X-RateLimit-Remaining"]
+        assert res.headers["X-RateLimit-Reset"]

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -9,6 +9,7 @@
 """Module tests."""
 
 from collections import namedtuple
+from importlib import import_module
 from unittest.mock import patch
 
 from flask import current_app
@@ -34,9 +35,10 @@ def test_limiter(app):
 
 
 FakeUser = namedtuple("User", ["is_authenticated"])
+limiter_module = import_module("invenio_app.limiter")
 
 
-@patch("invenio_app.limiter.current_user", FakeUser(is_authenticated=True))
+@patch.object(limiter_module, "current_user", FakeUser(is_authenticated=True))
 def test_limiter_for_authenticated_user(app):
     """Test the Flask limiter function."""
     with app.test_client() as client:
@@ -46,7 +48,7 @@ def test_limiter_for_authenticated_user(app):
         assert 200 == client.get("/unlimited_rate").status_code
 
 
-@patch("invenio_app.limiter.current_user", FakeUser(is_authenticated=True))
+@patch.object(limiter_module, "current_user", FakeUser(is_authenticated=True))
 def test_limiter_for_privileged_user(app, push_rate_limit_to_context):
     """Test the Flask limiter function."""
     with app.test_client() as client:


### PR DESCRIPTION
* Since there are no publicly breaking changes between the two major
  releases of Flask-Limiter, we can still support Python 3.9, by
  installing `Flask-Limiter==3.11`.
