### PR TITLE
Add RPC server

### DIFF
--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -1,11 +1,128 @@
 # SPDX-FileCopyrightText: 2017-2018 CERN.
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """CLI application for Invenio flavours."""
 
+import contextlib
+import io
+import socket
+import socketserver
+from pickle import dumps, loads
+
+from click import group, option, pass_context, secho
+from flask.cli import with_appcontext
 from invenio_base.app import create_cli
 
 from .factory import create_app
 
 #: Invenio CLI application.
 cli = create_cli(create_app=create_app)
+
+
+class RPCRequestHandler(socketserver.BaseRequestHandler):
+    """RPCRequestHandler."""
+
+    def handle(self):
+        """Handles the requests to the RPCServer."""
+        data = self.request.recv(4096)
+
+        if not data:
+            return
+
+        try:
+            command_parts = loads(data)
+
+            if not isinstance(command_parts, list) or len(command_parts) == 0:
+                raise ValueError("Invalid command format should be a list.")
+
+            if command_parts[0] == "ping":
+                result = "pong"
+            else:
+                output_buffer = io.StringIO()
+                with contextlib.redirect_stdout(output_buffer):
+                    cli.main(args=command_parts, standalone_mode=False)
+                result = output_buffer.getvalue().strip()
+
+            response = {"success": True, "result": result}
+        except Exception as e:
+            response = {"success": False, "error": str(e)}
+
+        self.request.sendall(dumps(response))
+
+
+class RPCServer(socketserver.TCPServer):
+    """RPCServer implementation."""
+
+    allow_reuse_address = True
+
+    def shutdown_server(self):
+        """Shutdown the server."""
+        secho("Shutting down RPC Server...", fg="green")
+        self.shutdown()
+        self.server_close()
+
+
+def send(host, port, args):
+    """Send."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((host, port))
+        s.sendall(dumps(list(args)))
+        return loads(s.recv(16384))
+
+
+@group()
+def rpc_server():
+    """RPC server."""
+
+
+@rpc_server.command("start")
+@option("--port", default=5000)
+@option("--host", default="localhost")
+@with_appcontext
+def rpc_server_start(port, host):
+    """Start rpc server."""
+    server = RPCServer((host, port), RPCRequestHandler)
+
+    secho(
+        f"RPC Server is running on port {host}:{port}... (Press Ctrl+C to stop)",
+        fg="green",
+    )
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+@rpc_server.command(
+    "send",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+@option("--port", default=5000)
+@option("--host", default="localhost")
+@option("--plain", is_flag=True, default=False)
+@pass_context
+def rpc_server_send(ctx, port, host, plain):
+    """Send."""
+    response = send(host, port, ctx.args)
+
+    if response["success"]:
+        prefix = "" if plain else "Response: "
+        color = "green"
+        message = response["result"]
+    else:
+        prefix = "" if plain else "Error: "
+        color = "red"
+        message = response["error"]
+
+    secho(f"{prefix}{message}", fg=color)
+
+
+@rpc_server.command("ping")
+@option("--port", default=5000)
+@option("--host", default="localhost")
+def rpc_server_ping(port, host):
+    """Ping."""
+    response = send(host, port, ["ping"])
+    secho(response["result"])

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -10,7 +10,7 @@ import socket
 import sys
 from pathlib import Path
 
-from click import ClickException, echo, group, option, pass_context, secho
+from click import ClickException, group, option, pass_context, secho
 from flask import current_app
 from flask.cli import ScriptInfo, with_appcontext
 from invenio_base.app import create_cli
@@ -44,10 +44,10 @@ def _ensure_socket_is_free(socket_path):
         probe.close()
 
 
-def _request_or_fail(socket_path, payload):
+def _request_or_fail(socket_path, payload, fds=None):
     """Send a request, turning connection problems into a CLI error."""
     try:
-        return send_request(socket_path, payload)
+        return send_request(socket_path, payload, fds=fds)
     except OSError as e:
         raise ClickException(f"No RPC server reachable on {socket_path} ({e}).")
 
@@ -104,14 +104,21 @@ def rpc_server_start(socket_path):
     "send",
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
-@socket_option
-@with_appcontext
+@option("--socket", "socket_path", required=True, help="Path to the server socket.")
 @pass_context
 def rpc_server_send(ctx, socket_path):
-    """Run a CLI command on the RPC server and relay its output."""
-    response = _request_or_fail(_socket_path(socket_path), {"argv": ctx.args})
-    if response["stdout"]:
-        echo(response["stdout"], nl=False)
-    if response["stderr"]:
-        echo(response["stderr"], nl=False, err=True)
+    """Run a CLI command on the RPC server, streaming its output here.
+
+    Takes an explicit socket path instead of deriving it from the app, so
+    no app is created and a bulk of sends only pays the import cost. The
+    command's stdout/stderr are passed to the server, which writes the
+    output straight to them, live and correctly interleaved.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    response = _request_or_fail(
+        socket_path,
+        {"argv": ctx.args},
+        fds=[sys.stdout.fileno(), sys.stderr.fileno()],
+    )
     sys.exit(response["exit_code"])

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -4,16 +4,10 @@
 
 """CLI application for Invenio flavours."""
 
-import array
-import json
 import os
 import signal
 import socket
-import socketserver
 import sys
-import traceback
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 from pathlib import Path
 
 from click import ClickException, echo, group, option, pass_context, secho
@@ -22,217 +16,10 @@ from flask.cli import ScriptInfo, with_appcontext
 from invenio_base.app import create_cli
 
 from .factory import create_app
+from .rpc import RPCServer, ServerStop, send_request
 
 #: Invenio CLI application.
 cli = create_cli(create_app=create_app)
-
-
-class ServerStop(BaseException):
-    """Raised by the SIGTERM handler to stop the server.
-
-    Derives from BaseException so a terminating signal that lands during a
-    command is not mistaken for the command's own SystemExit and reported
-    as its exit code.
-    """
-
-
-def error_response(message):
-    """Build the response for a malformed request."""
-    return {"exit_code": 2, "stdout": "", "stderr": message + "\n"}
-
-
-def recv_request(sock):
-    """Read one JSON line plus any file descriptors sent with it.
-
-    Also reports whether ancillary data was truncated (i.e. more
-    descriptors arrived than fit the buffer), so the caller can reject
-    the request instead of running it with silently dropped descriptors.
-    """
-    buf = b""
-    fds = []
-    truncated = False
-    fd_size = array.array("i").itemsize
-    while b"\n" not in buf:
-        data, ancdata, flags, _ = sock.recvmsg(65536, socket.CMSG_SPACE(2 * fd_size))
-        if not data:
-            break
-        truncated = truncated or bool(flags & socket.MSG_CTRUNC)
-        for level, ctype, cdata in ancdata:
-            if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
-                received = array.array("i")
-                received.frombytes(cdata[: len(cdata) - (len(cdata) % fd_size)])
-                fds.extend(received)
-        buf += data
-    return buf, fds, truncated
-
-
-class RPCRequestHandler(socketserver.BaseRequestHandler):
-    """Handler for newline-delimited JSON requests."""
-
-    def handle(self):
-        """Answer a single request with a single JSON line."""
-        line, fds, truncated = recv_request(self.request)
-        try:
-            if not line:
-                return
-
-            if truncated:
-                self.respond(
-                    error_response("Truncated file descriptor data (too many fds).")
-                )
-                return
-
-            try:
-                request = json.loads(line)
-            except ValueError:
-                self.respond(error_response("Request is not valid JSON."))
-                return
-
-            if request.get("ping"):
-                self.respond({"pong": True})
-                return
-
-            argv = request.get("argv")
-            if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
-                self.respond(error_response("'argv' must be a list of strings."))
-                return
-
-            if fds:
-                if len(fds) != 2:
-                    self.respond(
-                        error_response(
-                            "Expected two file descriptors (stdout, stderr)."
-                        )
-                    )
-                    return
-                self.respond(self.server.execute_redirected(argv, *fds))
-            else:
-                self.respond(self.server.execute(argv))
-        finally:
-            for fd in fds:
-                try:
-                    os.close(fd)
-                except OSError:
-                    pass
-
-    def respond(self, payload):
-        """Write a response as a single JSON line."""
-        self.request.sendall(json.dumps(payload).encode("utf-8") + b"\n")
-
-
-class RPCServer(socketserver.UnixStreamServer):
-    """Serve invenio CLI commands on a Unix domain socket.
-
-    Requests are handled one at a time, which also serializes commands sent
-    by concurrent clients.
-    """
-
-    def __init__(self, socket_path, script_info):
-        """Construct."""
-        self.script_info = script_info
-        super().__init__(str(socket_path), RPCRequestHandler)
-
-    def run_cli(self, argv):
-        """Run a CLI command and return its exit code.
-
-        Output goes to whatever ``sys.stdout``/``sys.stderr`` point at when
-        called. The shared ``ScriptInfo`` caches the Flask app, so only the
-        first command pays for the app creation. Each command runs in a
-        fresh app context (commands skip pushing their own when one is
-        already active), so ``flask.g`` and teardown handlers — e.g. the
-        SQLAlchemy session removal — behave per command, not per server
-        lifetime. ``standalone_mode`` makes click print usage errors itself
-        and exit with its usual exit codes.
-        """
-        try:
-            with self.script_info.load_app().app_context():
-                cli.main(
-                    args=argv,
-                    prog_name="invenio",
-                    obj=self.script_info,
-                    standalone_mode=True,
-                )
-        except SystemExit as e:
-            if e.code is None:
-                return 0
-            if isinstance(e.code, int):
-                return e.code
-            print(e.code, file=sys.stderr)
-            return 1
-        except Exception:
-            traceback.print_exc()
-            return 1
-        return 0
-
-    def execute(self, argv):
-        """Run a CLI command, capturing Python-level output in the response.
-
-        Output written directly to the file descriptors by subprocesses
-        (e.g. webpack builds) goes to the server's own stdout/stderr.
-        """
-        stdout, stderr = StringIO(), StringIO()
-        with redirect_stdout(stdout), redirect_stderr(stderr):
-            exit_code = self.run_cli(argv)
-        return {
-            "exit_code": exit_code,
-            "stdout": stdout.getvalue(),
-            "stderr": stderr.getvalue(),
-        }
-
-    def execute_redirected(self, argv, stdout_fd, stderr_fd):
-        """Run a CLI command with output sent straight to the given fds.
-
-        The client passes its own stdout/stderr (or a log file) over the
-        socket and the command's output streams there live. Both levels
-        are redirected: the process-level descriptors 1/2 (so subprocess
-        output like webpack builds arrives too) and the Python-level
-        ``sys.stdout``/``sys.stderr`` (for click/print output).
-        """
-        sys.stdout.flush()
-        sys.stderr.flush()
-        saved_stdout, saved_stderr = os.dup(1), os.dup(2)
-        os.dup2(stdout_fd, 1)
-        os.dup2(stderr_fd, 2)
-        # fdopen takes ownership, so hand it duplicates; the handler closes
-        # the received descriptors itself
-        out = os.fdopen(os.dup(stdout_fd), "w", buffering=1)
-        err = os.fdopen(os.dup(stderr_fd), "w", buffering=1)
-        try:
-            with redirect_stdout(out), redirect_stderr(err):
-                exit_code = self.run_cli(argv)
-        finally:
-            # restore our own stdio before anything that can raise — a
-            # close() flushes and fails on a client-closed pipe, and that
-            # must not leave fd 1/2 pointing at the dead client
-            os.dup2(saved_stdout, 1)
-            os.dup2(saved_stderr, 2)
-            os.close(saved_stdout)
-            os.close(saved_stderr)
-            for stream in (out, err):
-                try:
-                    stream.close()
-                except OSError:
-                    pass
-        return {"exit_code": exit_code}
-
-
-def send_request(socket_path, payload, fds=None):
-    """Send one request to a server and return the decoded response.
-
-    With ``fds`` (stdout, stderr) the command output is streamed straight
-    to those descriptors and the response carries only the exit code.
-    """
-    line = json.dumps(payload).encode("utf-8") + b"\n"
-    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
-        s.connect(str(socket_path))
-        if fds:
-            s.sendmsg(
-                [line], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))]
-            )
-        else:
-            s.sendall(line)
-        with s.makefile("rb") as f:
-            return json.loads(f.readline())
 
 
 def _socket_path(value):
@@ -290,7 +77,7 @@ def rpc_server_start(socket_path):
     # the app is already created thanks to with_appcontext; reuse it for
     # every request instead of creating one per command
     app = current_app._get_current_object()
-    server = RPCServer(socket_path, ScriptInfo(create_app=lambda: app))
+    server = RPCServer(socket_path, cli, ScriptInfo(create_app=lambda: app))
     os.chmod(socket_path, 0o600)
     pid_path.write_text(str(os.getpid()))
 

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -5,6 +5,8 @@
 """CLI application for Invenio flavours."""
 
 import json
+import os
+import signal
 import socket
 import socketserver
 import sys
@@ -15,7 +17,7 @@ from pathlib import Path
 
 from click import ClickException, echo, group, option, pass_context, secho
 from flask import current_app
-from flask.cli import with_appcontext
+from flask.cli import ScriptInfo, with_appcontext
 from invenio_base.app import create_cli
 
 from .factory import create_app
@@ -67,22 +69,31 @@ class RPCServer(socketserver.UnixStreamServer):
     by concurrent clients.
     """
 
-    def __init__(self, socket_path):
+    def __init__(self, socket_path, script_info):
         """Construct."""
+        self.script_info = script_info
         super().__init__(str(socket_path), RPCRequestHandler)
 
     def execute(self, argv):
         """Run a CLI command and capture its output and exit code.
 
-        Only Python-level output is captured; output written directly to the
-        file descriptors by subprocesses (e.g. webpack builds) goes to the
-        server's own stdout/stderr.
+        The shared ``ScriptInfo`` caches the Flask app, so only the first
+        command pays for the app creation. Only Python-level output is
+        captured; output written directly to the file descriptors by
+        subprocesses (e.g. webpack builds) goes to the server's own
+        stdout/stderr. ``standalone_mode`` makes click print usage errors
+        itself and exit with its usual exit codes.
         """
         stdout, stderr = StringIO(), StringIO()
         exit_code = 0
         with redirect_stdout(stdout), redirect_stderr(stderr):
             try:
-                cli.main(args=argv, prog_name="invenio", standalone_mode=False)
+                cli.main(
+                    args=argv,
+                    prog_name="invenio",
+                    obj=self.script_info,
+                    standalone_mode=True,
+                )
             except SystemExit as e:
                 if isinstance(e.code, int):
                     exit_code = e.code
@@ -157,17 +168,26 @@ def rpc_server():
 def rpc_server_start(socket_path):
     """Start the RPC server."""
     socket_path = _socket_path(socket_path)
+    pid_path = socket_path.with_suffix(".pid")
     _ensure_socket_is_free(socket_path)
 
-    server = RPCServer(socket_path)
+    # the app is already created thanks to with_appcontext; reuse it for
+    # every request instead of creating one per command
+    app = current_app._get_current_object()
+    server = RPCServer(socket_path, ScriptInfo(create_app=lambda: app))
+    os.chmod(socket_path, 0o600)
+    pid_path.write_text(str(os.getpid()))
+    signal.signal(signal.SIGTERM, lambda signo, frame: sys.exit(0))
+
     secho(f"RPC server listening on {socket_path} (Press Ctrl+C to stop)", fg="green")
     try:
         server.serve_forever()
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, SystemExit):
         pass
     finally:
         server.server_close()
         socket_path.unlink(missing_ok=True)
+        pid_path.unlink(missing_ok=True)
 
 
 @rpc_server.command(

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -1,16 +1,20 @@
-# SPDX-FileCopyrightText: 2017-2018 CERN.
+# SPDX-FileCopyrightText: 2017-2026 CERN.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """CLI application for Invenio flavours."""
 
-import contextlib
-import io
+import json
 import socket
 import socketserver
-from pickle import dumps, loads
+import sys
+import traceback
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
 
-from click import group, option, pass_context, secho
+from click import ClickException, echo, group, option, pass_context, secho
+from flask import current_app
 from flask.cli import with_appcontext
 from invenio_base.app import create_cli
 
@@ -20,55 +24,126 @@ from .factory import create_app
 cli = create_cli(create_app=create_app)
 
 
-class RPCRequestHandler(socketserver.BaseRequestHandler):
-    """RPCRequestHandler."""
+def error_response(message):
+    """Build the response for a malformed request."""
+    return {"exit_code": 2, "stdout": "", "stderr": message + "\n"}
+
+
+class RPCRequestHandler(socketserver.StreamRequestHandler):
+    """Handler for newline-delimited JSON requests."""
 
     def handle(self):
-        """Handles the requests to the RPCServer."""
-        data = self.request.recv(4096)
-
-        if not data:
+        """Answer a single request with a single JSON line."""
+        line = self.rfile.readline()
+        if not line:
             return
 
         try:
-            command_parts = loads(data)
+            request = json.loads(line)
+        except ValueError:
+            self.respond(error_response("Request is not valid JSON."))
+            return
 
-            if not isinstance(command_parts, list) or len(command_parts) == 0:
-                raise ValueError("Invalid command format should be a list.")
+        if request.get("ping"):
+            self.respond({"pong": True})
+            return
 
-            if command_parts[0] == "ping":
-                result = "pong"
-            else:
-                output_buffer = io.StringIO()
-                with contextlib.redirect_stdout(output_buffer):
-                    cli.main(args=command_parts, standalone_mode=False)
-                result = output_buffer.getvalue().strip()
+        argv = request.get("argv")
+        if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+            self.respond(error_response("'argv' must be a list of strings."))
+            return
 
-            response = {"success": True, "result": result}
-        except Exception as e:
-            response = {"success": False, "error": str(e)}
+        self.respond(self.server.execute(argv))
 
-        self.request.sendall(dumps(response))
-
-
-class RPCServer(socketserver.TCPServer):
-    """RPCServer implementation."""
-
-    allow_reuse_address = True
-
-    def shutdown_server(self):
-        """Shutdown the server."""
-        secho("Shutting down RPC Server...", fg="green")
-        self.shutdown()
-        self.server_close()
+    def respond(self, payload):
+        """Write a response as a single JSON line."""
+        self.wfile.write(json.dumps(payload).encode("utf-8") + b"\n")
 
 
-def send(host, port, args):
-    """Send."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.connect((host, port))
-        s.sendall(dumps(list(args)))
-        return loads(s.recv(16384))
+class RPCServer(socketserver.UnixStreamServer):
+    """Serve invenio CLI commands on a Unix domain socket.
+
+    Requests are handled one at a time, which also serializes commands sent
+    by concurrent clients.
+    """
+
+    def __init__(self, socket_path):
+        """Construct."""
+        super().__init__(str(socket_path), RPCRequestHandler)
+
+    def execute(self, argv):
+        """Run a CLI command and capture its output and exit code.
+
+        Only Python-level output is captured; output written directly to the
+        file descriptors by subprocesses (e.g. webpack builds) goes to the
+        server's own stdout/stderr.
+        """
+        stdout, stderr = StringIO(), StringIO()
+        exit_code = 0
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                cli.main(args=argv, prog_name="invenio", standalone_mode=False)
+            except SystemExit as e:
+                if isinstance(e.code, int):
+                    exit_code = e.code
+                elif e.code is not None:
+                    stderr.write(f"{e.code}\n")
+                    exit_code = 1
+            except Exception:
+                traceback.print_exc(file=stderr)
+                exit_code = 1
+        return {
+            "exit_code": exit_code,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+        }
+
+
+def send_request(socket_path, payload):
+    """Send one request to a server and return the decoded response."""
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+        s.connect(str(socket_path))
+        s.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+        with s.makefile("rb") as f:
+            return json.loads(f.readline())
+
+
+def _socket_path(value):
+    """Resolve the socket path, defaulting to the app instance directory."""
+    return Path(value) if value else Path(current_app.instance_path) / "rpc.sock"
+
+
+def _ensure_socket_is_free(socket_path):
+    """Remove a stale socket file, or fail if a server is listening on it."""
+    if not socket_path.exists():
+        return
+    probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        probe.settimeout(1)
+        probe.connect(str(socket_path))
+    except OSError:
+        # nothing is listening, the file was left behind by a dead server
+        socket_path.unlink()
+    else:
+        raise ClickException(f"An RPC server is already listening on {socket_path}.")
+    finally:
+        probe.close()
+
+
+def _request_or_fail(socket_path, payload):
+    """Send a request, turning connection problems into a CLI error."""
+    try:
+        return send_request(socket_path, payload)
+    except OSError as e:
+        raise ClickException(f"No RPC server reachable on {socket_path} ({e}).")
+
+
+socket_option = option(
+    "--socket",
+    "socket_path",
+    default=None,
+    help="Path to the server socket (default: <instance_path>/rpc.sock).",
+)
 
 
 @group()
@@ -77,52 +152,47 @@ def rpc_server():
 
 
 @rpc_server.command("start")
-@option("--port", default=5000)
-@option("--host", default="localhost")
+@socket_option
 @with_appcontext
-def rpc_server_start(port, host):
-    """Start rpc server."""
-    server = RPCServer((host, port), RPCRequestHandler)
+def rpc_server_start(socket_path):
+    """Start the RPC server."""
+    socket_path = _socket_path(socket_path)
+    _ensure_socket_is_free(socket_path)
 
-    secho(
-        f"RPC Server is running on port {host}:{port}... (Press Ctrl+C to stop)",
-        fg="green",
-    )
-
+    server = RPCServer(socket_path)
+    secho(f"RPC server listening on {socket_path} (Press Ctrl+C to stop)", fg="green")
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        server.shutdown()
+        pass
+    finally:
+        server.server_close()
+        socket_path.unlink(missing_ok=True)
 
 
 @rpc_server.command(
     "send",
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
-@option("--port", default=5000)
-@option("--host", default="localhost")
-@option("--plain", is_flag=True, default=False)
+@socket_option
+@with_appcontext
 @pass_context
-def rpc_server_send(ctx, port, host, plain):
-    """Send."""
-    response = send(host, port, ctx.args)
-
-    if response["success"]:
-        prefix = "" if plain else "Response: "
-        color = "green"
-        message = response["result"]
-    else:
-        prefix = "" if plain else "Error: "
-        color = "red"
-        message = response["error"]
-
-    secho(f"{prefix}{message}", fg=color)
+def rpc_server_send(ctx, socket_path):
+    """Run a CLI command on the RPC server and relay its output."""
+    response = _request_or_fail(_socket_path(socket_path), {"argv": ctx.args})
+    if response["stdout"]:
+        echo(response["stdout"], nl=False)
+    if response["stderr"]:
+        echo(response["stderr"], nl=False, err=True)
+    sys.exit(response["exit_code"])
 
 
 @rpc_server.command("ping")
-@option("--port", default=5000)
-@option("--host", default="localhost")
-def rpc_server_ping(port, host):
-    """Ping."""
-    response = send(host, port, ["ping"])
-    secho(response["result"])
+@socket_option
+@with_appcontext
+def rpc_server_ping(socket_path):
+    """Check whether the RPC server responds."""
+    response = _request_or_fail(_socket_path(socket_path), {"ping": True})
+    if not response.get("pong"):
+        raise ClickException("Unexpected response from the RPC server.")
+    secho("pong", fg="green")

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -4,6 +4,7 @@
 
 """CLI application for Invenio flavours."""
 
+import array
 import json
 import os
 import signal
@@ -31,35 +32,70 @@ def error_response(message):
     return {"exit_code": 2, "stdout": "", "stderr": message + "\n"}
 
 
-class RPCRequestHandler(socketserver.StreamRequestHandler):
+def recv_request(sock):
+    """Read one JSON line plus any file descriptors sent with it."""
+    buf = b""
+    fds = []
+    fd_size = array.array("i").itemsize
+    while b"\n" not in buf:
+        data, ancdata, _, _ = sock.recvmsg(65536, socket.CMSG_SPACE(2 * fd_size))
+        if not data:
+            break
+        for level, ctype, cdata in ancdata:
+            if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
+                received = array.array("i")
+                received.frombytes(cdata[: len(cdata) - (len(cdata) % fd_size)])
+                fds.extend(received)
+        buf += data
+    return buf, fds
+
+
+class RPCRequestHandler(socketserver.BaseRequestHandler):
     """Handler for newline-delimited JSON requests."""
 
     def handle(self):
         """Answer a single request with a single JSON line."""
-        line = self.rfile.readline()
-        if not line:
-            return
-
+        line, fds = recv_request(self.request)
         try:
-            request = json.loads(line)
-        except ValueError:
-            self.respond(error_response("Request is not valid JSON."))
-            return
+            if not line:
+                return
 
-        if request.get("ping"):
-            self.respond({"pong": True})
-            return
+            try:
+                request = json.loads(line)
+            except ValueError:
+                self.respond(error_response("Request is not valid JSON."))
+                return
 
-        argv = request.get("argv")
-        if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
-            self.respond(error_response("'argv' must be a list of strings."))
-            return
+            if request.get("ping"):
+                self.respond({"pong": True})
+                return
 
-        self.respond(self.server.execute(argv))
+            argv = request.get("argv")
+            if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+                self.respond(error_response("'argv' must be a list of strings."))
+                return
+
+            if fds:
+                if len(fds) != 2:
+                    self.respond(
+                        error_response(
+                            "Expected two file descriptors (stdout, stderr)."
+                        )
+                    )
+                    return
+                self.respond(self.server.execute_redirected(argv, *fds))
+            else:
+                self.respond(self.server.execute(argv))
+        finally:
+            for fd in fds:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
     def respond(self, payload):
         """Write a response as a single JSON line."""
-        self.wfile.write(json.dumps(payload).encode("utf-8") + b"\n")
+        self.request.sendall(json.dumps(payload).encode("utf-8") + b"\n")
 
 
 class RPCServer(socketserver.UnixStreamServer):
@@ -74,47 +110,94 @@ class RPCServer(socketserver.UnixStreamServer):
         self.script_info = script_info
         super().__init__(str(socket_path), RPCRequestHandler)
 
-    def execute(self, argv):
-        """Run a CLI command and capture its output and exit code.
+    def run_cli(self, argv):
+        """Run a CLI command and return its exit code.
 
-        The shared ``ScriptInfo`` caches the Flask app, so only the first
-        command pays for the app creation. Only Python-level output is
-        captured; output written directly to the file descriptors by
-        subprocesses (e.g. webpack builds) goes to the server's own
-        stdout/stderr. ``standalone_mode`` makes click print usage errors
-        itself and exit with its usual exit codes.
+        Output goes to whatever ``sys.stdout``/``sys.stderr`` point at when
+        called. The shared ``ScriptInfo`` caches the Flask app, so only the
+        first command pays for the app creation. ``standalone_mode`` makes
+        click print usage errors itself and exit with its usual exit codes.
+        """
+        try:
+            cli.main(
+                args=argv,
+                prog_name="invenio",
+                obj=self.script_info,
+                standalone_mode=True,
+            )
+        except SystemExit as e:
+            if e.code is None:
+                return 0
+            if isinstance(e.code, int):
+                return e.code
+            print(e.code, file=sys.stderr)
+            return 1
+        except Exception:
+            traceback.print_exc()
+            return 1
+        return 0
+
+    def execute(self, argv):
+        """Run a CLI command, capturing Python-level output in the response.
+
+        Output written directly to the file descriptors by subprocesses
+        (e.g. webpack builds) goes to the server's own stdout/stderr.
         """
         stdout, stderr = StringIO(), StringIO()
-        exit_code = 0
         with redirect_stdout(stdout), redirect_stderr(stderr):
-            try:
-                cli.main(
-                    args=argv,
-                    prog_name="invenio",
-                    obj=self.script_info,
-                    standalone_mode=True,
-                )
-            except SystemExit as e:
-                if isinstance(e.code, int):
-                    exit_code = e.code
-                elif e.code is not None:
-                    stderr.write(f"{e.code}\n")
-                    exit_code = 1
-            except Exception:
-                traceback.print_exc(file=stderr)
-                exit_code = 1
+            exit_code = self.run_cli(argv)
         return {
             "exit_code": exit_code,
             "stdout": stdout.getvalue(),
             "stderr": stderr.getvalue(),
         }
 
+    def execute_redirected(self, argv, stdout_fd, stderr_fd):
+        """Run a CLI command with output sent straight to the given fds.
 
-def send_request(socket_path, payload):
-    """Send one request to a server and return the decoded response."""
+        The client passes its own stdout/stderr (or a log file) over the
+        socket and the command's output streams there live. Both levels
+        are redirected: the process-level descriptors 1/2 (so subprocess
+        output like webpack builds arrives too) and the Python-level
+        ``sys.stdout``/``sys.stderr`` (for click/print output).
+        """
+        sys.stdout.flush()
+        sys.stderr.flush()
+        saved_stdout, saved_stderr = os.dup(1), os.dup(2)
+        os.dup2(stdout_fd, 1)
+        os.dup2(stderr_fd, 2)
+        # fdopen takes ownership, so hand it duplicates; the handler closes
+        # the received descriptors itself
+        out = os.fdopen(os.dup(stdout_fd), "w", buffering=1)
+        err = os.fdopen(os.dup(stderr_fd), "w", buffering=1)
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                exit_code = self.run_cli(argv)
+        finally:
+            out.close()
+            err.close()
+            os.dup2(saved_stdout, 1)
+            os.dup2(saved_stderr, 2)
+            os.close(saved_stdout)
+            os.close(saved_stderr)
+        return {"exit_code": exit_code}
+
+
+def send_request(socket_path, payload, fds=None):
+    """Send one request to a server and return the decoded response.
+
+    With ``fds`` (stdout, stderr) the command output is streamed straight
+    to those descriptors and the response carries only the exit code.
+    """
+    line = json.dumps(payload).encode("utf-8") + b"\n"
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
         s.connect(str(socket_path))
-        s.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+        if fds:
+            s.sendmsg(
+                [line], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))]
+            )
+        else:
+            s.sendall(line)
         with s.makefile("rb") as f:
             return json.loads(f.readline())
 
@@ -178,6 +261,8 @@ def rpc_server_start(socket_path):
     os.chmod(socket_path, 0o600)
     pid_path.write_text(str(os.getpid()))
     signal.signal(signal.SIGTERM, lambda signo, frame: sys.exit(0))
+    # stream promptly when output is forwarded to a client terminal
+    sys.stdout.reconfigure(line_buffering=True)
 
     secho(f"RPC server listening on {socket_path} (Press Ctrl+C to stop)", fg="green")
     try:

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -27,27 +27,43 @@ from .factory import create_app
 cli = create_cli(create_app=create_app)
 
 
+class ServerStop(BaseException):
+    """Raised by the SIGTERM handler to stop the server.
+
+    Derives from BaseException so a terminating signal that lands during a
+    command is not mistaken for the command's own SystemExit and reported
+    as its exit code.
+    """
+
+
 def error_response(message):
     """Build the response for a malformed request."""
     return {"exit_code": 2, "stdout": "", "stderr": message + "\n"}
 
 
 def recv_request(sock):
-    """Read one JSON line plus any file descriptors sent with it."""
+    """Read one JSON line plus any file descriptors sent with it.
+
+    Also reports whether ancillary data was truncated (i.e. more
+    descriptors arrived than fit the buffer), so the caller can reject
+    the request instead of running it with silently dropped descriptors.
+    """
     buf = b""
     fds = []
+    truncated = False
     fd_size = array.array("i").itemsize
     while b"\n" not in buf:
-        data, ancdata, _, _ = sock.recvmsg(65536, socket.CMSG_SPACE(2 * fd_size))
+        data, ancdata, flags, _ = sock.recvmsg(65536, socket.CMSG_SPACE(2 * fd_size))
         if not data:
             break
+        truncated = truncated or bool(flags & socket.MSG_CTRUNC)
         for level, ctype, cdata in ancdata:
             if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
                 received = array.array("i")
                 received.frombytes(cdata[: len(cdata) - (len(cdata) % fd_size)])
                 fds.extend(received)
         buf += data
-    return buf, fds
+    return buf, fds, truncated
 
 
 class RPCRequestHandler(socketserver.BaseRequestHandler):
@@ -55,9 +71,15 @@ class RPCRequestHandler(socketserver.BaseRequestHandler):
 
     def handle(self):
         """Answer a single request with a single JSON line."""
-        line, fds = recv_request(self.request)
+        line, fds, truncated = recv_request(self.request)
         try:
             if not line:
+                return
+
+            if truncated:
+                self.respond(
+                    error_response("Truncated file descriptor data (too many fds).")
+                )
                 return
 
             try:
@@ -115,16 +137,21 @@ class RPCServer(socketserver.UnixStreamServer):
 
         Output goes to whatever ``sys.stdout``/``sys.stderr`` point at when
         called. The shared ``ScriptInfo`` caches the Flask app, so only the
-        first command pays for the app creation. ``standalone_mode`` makes
-        click print usage errors itself and exit with its usual exit codes.
+        first command pays for the app creation. Each command runs in a
+        fresh app context (commands skip pushing their own when one is
+        already active), so ``flask.g`` and teardown handlers — e.g. the
+        SQLAlchemy session removal — behave per command, not per server
+        lifetime. ``standalone_mode`` makes click print usage errors itself
+        and exit with its usual exit codes.
         """
         try:
-            cli.main(
-                args=argv,
-                prog_name="invenio",
-                obj=self.script_info,
-                standalone_mode=True,
-            )
+            with self.script_info.load_app().app_context():
+                cli.main(
+                    args=argv,
+                    prog_name="invenio",
+                    obj=self.script_info,
+                    standalone_mode=True,
+                )
         except SystemExit as e:
             if e.code is None:
                 return 0
@@ -174,12 +201,18 @@ class RPCServer(socketserver.UnixStreamServer):
             with redirect_stdout(out), redirect_stderr(err):
                 exit_code = self.run_cli(argv)
         finally:
-            out.close()
-            err.close()
+            # restore our own stdio before anything that can raise — a
+            # close() flushes and fails on a client-closed pipe, and that
+            # must not leave fd 1/2 pointing at the dead client
             os.dup2(saved_stdout, 1)
             os.dup2(saved_stderr, 2)
             os.close(saved_stdout)
             os.close(saved_stderr)
+            for stream in (out, err):
+                try:
+                    stream.close()
+                except OSError:
+                    pass
         return {"exit_code": exit_code}
 
 
@@ -260,14 +293,19 @@ def rpc_server_start(socket_path):
     server = RPCServer(socket_path, ScriptInfo(create_app=lambda: app))
     os.chmod(socket_path, 0o600)
     pid_path.write_text(str(os.getpid()))
-    signal.signal(signal.SIGTERM, lambda signo, frame: sys.exit(0))
+
+    def stop(signo, frame):
+        """Translate SIGTERM into a ServerStop exception."""
+        raise ServerStop()
+
+    signal.signal(signal.SIGTERM, stop)
     # stream promptly when output is forwarded to a client terminal
     sys.stdout.reconfigure(line_buffering=True)
 
     secho(f"RPC server listening on {socket_path} (Press Ctrl+C to stop)", fg="green")
     try:
         server.serve_forever()
-    except (KeyboardInterrupt, SystemExit):
+    except (KeyboardInterrupt, ServerStop):
         pass
     finally:
         server.server_close()

--- a/invenio_app/cli.py
+++ b/invenio_app/cli.py
@@ -115,14 +115,3 @@ def rpc_server_send(ctx, socket_path):
     if response["stderr"]:
         echo(response["stderr"], nl=False, err=True)
     sys.exit(response["exit_code"])
-
-
-@rpc_server.command("ping")
-@socket_option
-@with_appcontext
-def rpc_server_ping(socket_path):
-    """Check whether the RPC server responds."""
-    response = _request_or_fail(_socket_path(socket_path), {"ping": True})
-    if not response.get("pong"):
-        raise ClickException("Unexpected response from the RPC server.")
-    secho("pong", fg="green")

--- a/invenio_app/config.py
+++ b/invenio_app/config.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2017-2018 CERN.
-# SPDX-FileCopyrightText: 2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Invenio App configuration.
@@ -201,3 +201,6 @@ add it as a header to both the upstream WSGI server and downstream client::
 
 Set to ``None`` to not extract a request id.
 """
+
+FLASK_DEBUGTOOLBAR_ENABLED = True
+"""Make it possible to disable the warning."""

--- a/invenio_app/ext.py
+++ b/invenio_app/ext.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2017-2026 CERN.
-# SPDX-FileCopyrightText: 2022-2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2022-2026 Graz University of Technology.
 # SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
@@ -168,7 +168,8 @@ class InvenioApp(object):
 
             app.extensions["flask-debugtoolbar"] = DebugToolbarExtension(app)
         except ImportError:
-            app.logger.debug("Flask-DebugToolbar extension not installed.")
+            if app.config["FLASK_DEBUGTOOLBAR_ENABLED"]:
+                app.logger.debug("Flask-DebugToolbar extension not installed.")
 
         # Add theme template loader
         if app.config.get("APP_THEME"):
@@ -190,7 +191,7 @@ class InvenioApp(object):
                 DeprecationWarning,
             )
 
-        config_apps = ["APP_", "RATELIMIT_"]
+        config_apps = ["APP_", "RATELIMIT_", "FLASK_"]
         flask_talisman_debug_mode = "'unsafe-inline'"
         for k in dir(config):
             if any([k.startswith(prefix) for prefix in config_apps]):

--- a/invenio_app/rpc.py
+++ b/invenio_app/rpc.py
@@ -88,10 +88,6 @@ class RPCRequestHandler(socketserver.BaseRequestHandler):
                 self.respond(error_response("Request is not valid JSON."))
                 return
 
-            if request.get("ping"):
-                self.respond({"pong": True})
-                return
-
             argv = request.get("argv")
             if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
                 self.respond(error_response("'argv' must be a list of strings."))

--- a/invenio_app/rpc.py
+++ b/invenio_app/rpc.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+# Copyright (C) 2025 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""RPC server running CLI commands in a long-lived process.
+
+Clients (e.g. invenio-cli) send one JSON line per request over a Unix
+domain socket (``{"argv": [...]}``) and get one JSON line back. When the
+request carries the client's stdout/stderr file descriptors (SCM_RIGHTS),
+the command output streams straight to them and the response is only the
+exit code; otherwise the captured output is returned on the response.
+"""
+
+import array
+import json
+import os
+import socket
+import socketserver
+import sys
+import traceback
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+
+
+class ServerStop(BaseException):
+    """Raised by a SIGTERM handler to stop the server.
+
+    Derives from BaseException so a terminating signal that lands during a
+    command is not mistaken for the command's own SystemExit and reported
+    as its exit code.
+    """
+
+
+def error_response(message):
+    """Build the response for a malformed request."""
+    return {"exit_code": 2, "stdout": "", "stderr": message + "\n"}
+
+
+def recv_request(sock):
+    """Read one JSON line plus any file descriptors sent with it.
+
+    Also reports whether ancillary data was truncated (i.e. more
+    descriptors arrived than fit the buffer), so the caller can reject
+    the request instead of running it with silently dropped descriptors.
+    """
+    buf = b""
+    fds = []
+    truncated = False
+    fd_size = array.array("i").itemsize
+    while b"\n" not in buf:
+        data, ancdata, flags, _ = sock.recvmsg(65536, socket.CMSG_SPACE(2 * fd_size))
+        if not data:
+            break
+        truncated = truncated or bool(flags & socket.MSG_CTRUNC)
+        for level, ctype, cdata in ancdata:
+            if level == socket.SOL_SOCKET and ctype == socket.SCM_RIGHTS:
+                received = array.array("i")
+                received.frombytes(cdata[: len(cdata) - (len(cdata) % fd_size)])
+                fds.extend(received)
+        buf += data
+    return buf, fds, truncated
+
+
+class RPCRequestHandler(socketserver.BaseRequestHandler):
+    """Handler for newline-delimited JSON requests."""
+
+    def handle(self):
+        """Answer a single request with a single JSON line."""
+        line, fds, truncated = recv_request(self.request)
+        try:
+            if not line:
+                return
+
+            if truncated:
+                self.respond(
+                    error_response("Truncated file descriptor data (too many fds).")
+                )
+                return
+
+            try:
+                request = json.loads(line)
+            except ValueError:
+                self.respond(error_response("Request is not valid JSON."))
+                return
+
+            if request.get("ping"):
+                self.respond({"pong": True})
+                return
+
+            argv = request.get("argv")
+            if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+                self.respond(error_response("'argv' must be a list of strings."))
+                return
+
+            if fds:
+                if len(fds) != 2:
+                    self.respond(
+                        error_response(
+                            "Expected two file descriptors (stdout, stderr)."
+                        )
+                    )
+                    return
+                self.respond(self.server.execute_redirected(argv, *fds))
+            else:
+                self.respond(self.server.execute(argv))
+        finally:
+            for fd in fds:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+    def respond(self, payload):
+        """Write a response as a single JSON line."""
+        self.request.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+
+
+class RPCServer(socketserver.UnixStreamServer):
+    """Serve commands of a click CLI on a Unix domain socket.
+
+    Requests are handled one at a time, which also serializes commands sent
+    by concurrent clients.
+    """
+
+    def __init__(self, socket_path, cli, script_info):
+        """Construct."""
+        self.cli = cli
+        self.script_info = script_info
+        super().__init__(str(socket_path), RPCRequestHandler)
+
+    def run_cli(self, argv):
+        """Run a CLI command and return its exit code.
+
+        Output goes to whatever ``sys.stdout``/``sys.stderr`` point at when
+        called. The shared ``ScriptInfo`` caches the Flask app, so only the
+        first command pays for the app creation. Each command runs in a
+        fresh app context (commands skip pushing their own when one is
+        already active), so ``flask.g`` and teardown handlers — e.g. the
+        SQLAlchemy session removal — behave per command, not per server
+        lifetime. ``standalone_mode`` makes click print usage errors itself
+        and exit with its usual exit codes.
+        """
+        try:
+            with self.script_info.load_app().app_context():
+                self.cli.main(
+                    args=argv,
+                    prog_name="invenio",
+                    obj=self.script_info,
+                    standalone_mode=True,
+                )
+        except SystemExit as e:
+            if e.code is None:
+                return 0
+            if isinstance(e.code, int):
+                return e.code
+            print(e.code, file=sys.stderr)
+            return 1
+        except Exception:
+            traceback.print_exc()
+            return 1
+        return 0
+
+    def execute(self, argv):
+        """Run a CLI command, capturing Python-level output in the response.
+
+        Output written directly to the file descriptors by subprocesses
+        (e.g. webpack builds) goes to the server's own stdout/stderr.
+        """
+        stdout, stderr = StringIO(), StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = self.run_cli(argv)
+        return {
+            "exit_code": exit_code,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+        }
+
+    def execute_redirected(self, argv, stdout_fd, stderr_fd):
+        """Run a CLI command with output sent straight to the given fds.
+
+        The client passes its own stdout/stderr (or a log file) over the
+        socket and the command's output streams there live. Both levels
+        are redirected: the process-level descriptors 1/2 (so subprocess
+        output like webpack builds arrives too) and the Python-level
+        ``sys.stdout``/``sys.stderr`` (for click/print output).
+        """
+        sys.stdout.flush()
+        sys.stderr.flush()
+        saved_stdout, saved_stderr = os.dup(1), os.dup(2)
+        os.dup2(stdout_fd, 1)
+        os.dup2(stderr_fd, 2)
+        # fdopen takes ownership, so hand it duplicates; the handler closes
+        # the received descriptors itself
+        out = os.fdopen(os.dup(stdout_fd), "w", buffering=1)
+        err = os.fdopen(os.dup(stderr_fd), "w", buffering=1)
+        try:
+            with redirect_stdout(out), redirect_stderr(err):
+                exit_code = self.run_cli(argv)
+        finally:
+            # restore our own stdio before anything that can raise — a
+            # close() flushes and fails on a client-closed pipe, and that
+            # must not leave fd 1/2 pointing at the dead client
+            os.dup2(saved_stdout, 1)
+            os.dup2(saved_stderr, 2)
+            os.close(saved_stdout)
+            os.close(saved_stderr)
+            for stream in (out, err):
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+        return {"exit_code": exit_code}
+
+
+def send_request(socket_path, payload, fds=None):
+    """Send one request to a server and return the decoded response.
+
+    With ``fds`` (stdout, stderr) the command output is streamed straight
+    to those descriptors and the response carries only the exit code.
+    """
+    line = json.dumps(payload).encode("utf-8") + b"\n"
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+        s.connect(str(socket_path))
+        if fds:
+            s.sendmsg(
+                [line], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", fds))]
+            )
+        else:
+            s.sendall(line)
+        with s.makefile("rb") as f:
+            return json.loads(f.readline())

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,9 @@ tests =
 [options.entry_points]
 console_scripts =
     invenio = invenio_app.cli:cli
+    rpc-server = invenio_app.cli:rpc_server
+flask.commands =
+    rpc-server = invenio_app.cli:rpc_server
 invenio_base.api_apps =
     invenio_app = invenio_app:InvenioApp
 invenio_base.apps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ tests =
 [options.entry_points]
 console_scripts =
     invenio = invenio_app.cli:cli
-    rpc-server = invenio_app.cli:rpc_server
 flask.commands =
     rpc-server = invenio_app.cli:rpc_server
 invenio_base.api_apps =

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ tests =
 [options.entry_points]
 console_scripts =
     invenio = invenio_app.cli:cli
+    rpc-server = invenio_app.cli:rpc_server
 flask.commands =
     rpc-server = invenio_app.cli:rpc_server
 invenio_base.api_apps =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2017-2026 CERN.
-# SPDX-FileCopyrightText: 2022-2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2022-2026 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Pytest configuration."""
@@ -71,6 +71,7 @@ def app(base_app, fresh_limiter_instance):
         RATELIMIT_AUTHENTICATED_USER="5 per second",
         RATELIMIT_PER_ENDPOINT={"unlimited_rate": "200 per second"},
         RATELIMIT_HEADERS_ENABLED=True,
+        RATELIMIT_STORAGE_URI="memory://",
     )
     Limiter(
         app=base_app,

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: 2017-2018 CERN.
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Celery test."""
 
+import os
+
 
 def test_celery():
     """Test celery application."""
+    os.environ["INVENIO_SECRET_KEY"] = "CHANGE_ME"
     from invenio_app.celery import celery
 
     celery.loader.import_default_modules()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,10 @@ import importlib.metadata
 from click.testing import CliRunner
 
 
-def test_basic_cli():
+def test_basic_cli(app_config):
     """Test version import."""
+    app_config["SECRET_KEY"] = "CHANGE_ME"
+
     from invenio_app.cli import cli
 
     res = CliRunner().invoke(cli)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2017-2019 CERN.
-# SPDX-FileCopyrightText: 2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2024-2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Module tests."""
@@ -18,7 +18,7 @@ def test_version():
 
 def test_config_loader():
     """Test config loader."""
-    app = create_ui()
+    app = create_ui(SECRET_KEY="CHANGE_ME")
     assert app.jinja_env.cache_size == 1000
 
 
@@ -28,6 +28,7 @@ def test_trusted_hosts():
         TRUSTED_HOSTS=["example.org", "www.example.org"],
         APP_ENABLE_SECURE_HEADERS=False,
         RATELIMIT_ENABLED=False,
+        SECRET_KEY="CHANGE_ME",
     )
 
     @app.route("/host")

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -15,12 +15,13 @@ import threading
 from pathlib import Path
 
 import pytest
+from flask.cli import ScriptInfo
 
 from invenio_app.cli import RPCServer, send_request
 
 
 @pytest.fixture()
-def rpc_socket():
+def rpc_socket(base_app):
     """A running RPC server on a temporary socket.
 
     Uses a short-lived directory under /tmp because AF_UNIX paths are
@@ -28,7 +29,7 @@ def rpc_socket():
     """
     tmp_dir = tempfile.TemporaryDirectory(prefix="rpc", dir="/tmp")
     socket_path = Path(tmp_dir.name) / "rpc.sock"
-    server = RPCServer(socket_path)
+    server = RPCServer(socket_path, ScriptInfo(create_app=lambda: base_app))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     yield socket_path
@@ -64,3 +65,18 @@ def test_argv_must_be_a_list_of_strings(rpc_socket):
     response = send_request(rpc_socket, {"argv": "collect"})
     assert response["exit_code"] == 2
     assert "list of strings" in response["stderr"]
+
+
+def test_command_stdout_and_exit_code(rpc_socket):
+    """A successful command returns its stdout and exit code 0."""
+    response = send_request(rpc_socket, {"argv": ["--help"]})
+    assert response["exit_code"] == 0
+    assert "Usage: invenio" in response["stdout"]
+    assert response["stderr"] == ""
+
+
+def test_unknown_command(rpc_socket):
+    """Usage errors come back on stderr with click's exit code."""
+    response = send_request(rpc_socket, {"argv": ["definitely-not-a-command"]})
+    assert response["exit_code"] == 2
+    assert "No such command" in response["stderr"]

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -16,6 +16,7 @@ import threading
 from pathlib import Path
 
 import pytest
+from flask import g
 from flask.cli import ScriptInfo
 
 from invenio_app.cli import RPCServer, send_request
@@ -117,3 +118,49 @@ def test_wrong_fd_count_is_rejected(rpc_socket):
     os.close(read_end)
     assert response["exit_code"] == 2
     assert "two file descriptors" in response["stderr"]
+
+
+def test_too_many_fds_are_rejected(rpc_socket):
+    """Descriptors beyond stdout/stderr truncate and reject the request."""
+    pipes = [os.pipe() for _ in range(3)]
+    response = send_request(
+        rpc_socket, {"argv": ["--help"]}, fds=[write_end for _, write_end in pipes]
+    )
+    for read_end, write_end in pipes:
+        os.close(read_end)
+        os.close(write_end)
+    assert response["exit_code"] == 2
+    assert "Truncated" in response["stderr"]
+
+
+def test_each_command_gets_a_fresh_app_context(rpc_socket, base_app):
+    """flask.g must not leak from one command into the next."""
+
+    @base_app.cli.command("g-probe")
+    def g_probe():
+        """Print the leftover value, then pollute flask.g."""
+        print(g.get("probe"))
+        g.probe = "leaked"
+
+    first = send_request(rpc_socket, {"argv": ["g-probe"]})
+    second = send_request(rpc_socket, {"argv": ["g-probe"]})
+    assert first["stdout"] == "None\n"
+    assert second["stdout"] == "None\n"
+
+
+def test_server_survives_a_client_with_closed_pipes(rpc_socket):
+    """A broken client pipe must not wedge the server's own stdio."""
+    out_read, out_write = os.pipe()
+    err_read, err_write = os.pipe()
+    # close the read ends so the server writes into broken pipes
+    os.close(out_read)
+    os.close(err_read)
+    try:
+        send_request(rpc_socket, {"argv": ["--help"]}, fds=[out_write, err_write])
+    except ValueError:
+        pass  # the connection may drop without a response
+    os.close(out_write)
+    os.close(err_write)
+
+    assert send_request(rpc_socket, {"ping": True}) == {"pong": True}
+    assert send_request(rpc_socket, {"argv": ["--help"]})["exit_code"] == 0

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -9,6 +9,7 @@
 """RPC server tests."""
 
 import json
+import os
 import socket
 import tempfile
 import threading
@@ -80,3 +81,39 @@ def test_unknown_command(rpc_socket):
     response = send_request(rpc_socket, {"argv": ["definitely-not-a-command"]})
     assert response["exit_code"] == 2
     assert "No such command" in response["stderr"]
+
+
+def _read_all(fd):
+    """Read from fd until EOF."""
+    chunks = []
+    while chunk := os.read(fd, 4096):
+        chunks.append(chunk)
+    os.close(fd)
+    return b"".join(chunks)
+
+
+def test_output_streams_to_passed_fds(rpc_socket):
+    """With fds attached, output streams to them and only the code returns."""
+    out_read, out_write = os.pipe()
+    err_read, err_write = os.pipe()
+    response = send_request(
+        rpc_socket, {"argv": ["--help"]}, fds=[out_write, err_write]
+    )
+    # close our copies so reading the pipes terminates once the server
+    # closes its received descriptors
+    os.close(out_write)
+    os.close(err_write)
+
+    assert response == {"exit_code": 0}
+    assert b"Usage: invenio" in _read_all(out_read)
+    assert _read_all(err_read) == b""
+
+
+def test_wrong_fd_count_is_rejected(rpc_socket):
+    """Sending a single fd is an error, not a crash."""
+    read_end, write_end = os.pipe()
+    response = send_request(rpc_socket, {"argv": ["--help"]}, fds=[write_end])
+    os.close(write_end)
+    os.close(read_end)
+    assert response["exit_code"] == 2
+    assert "two file descriptors" in response["stderr"]

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -11,6 +11,8 @@
 import json
 import os
 import socket
+import subprocess
+import sys
 import tempfile
 import threading
 from pathlib import Path
@@ -144,6 +146,27 @@ def test_each_command_gets_a_fresh_app_context(rpc_socket, base_app):
     second = send_request(rpc_socket, {"argv": ["g-probe"]})
     assert first["stdout"] == "None\n"
     assert second["stdout"] == "None\n"
+
+
+def test_standalone_send_streams_output_and_exit_codes(rpc_socket):
+    """The app-free rpc-server script relays fd-forwarded output."""
+    rpc_server_bin = Path(sys.executable).parent / "rpc-server"
+
+    ok = subprocess.run(
+        [rpc_server_bin, "send", "--socket", str(rpc_socket), "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert ok.returncode == 0
+    assert "Flask" in ok.stdout
+
+    bad = subprocess.run(
+        [rpc_server_bin, "send", "--socket", str(rpc_socket), "no-such-cmd"],
+        capture_output=True,
+        text=True,
+    )
+    assert bad.returncode == 2
+    assert "No such command" in bad.stderr
 
 
 def test_server_survives_a_client_with_closed_pipes(rpc_socket):

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -41,15 +41,12 @@ def rpc_socket(base_app):
     tmp_dir.cleanup()
 
 
-def test_ping(rpc_socket):
-    """The server answers a ping."""
-    assert send_request(rpc_socket, {"ping": True}) == {"pong": True}
-
-
 def test_request_larger_than_a_socket_buffer(rpc_socket):
     """Requests are framed by line, not by a fixed read size."""
-    request = {"ping": True, "padding": "x" * 100_000}
-    assert send_request(rpc_socket, request) == {"pong": True}
+    request = {"argv": ["--help"], "padding": "x" * 100_000}
+    response = send_request(rpc_socket, request)
+    assert response["exit_code"] == 0
+    assert "Usage: invenio" in response["stdout"]
 
 
 def test_invalid_json(rpc_socket):
@@ -163,5 +160,4 @@ def test_server_survives_a_client_with_closed_pipes(rpc_socket):
     os.close(out_write)
     os.close(err_write)
 
-    assert send_request(rpc_socket, {"ping": True}) == {"pong": True}
     assert send_request(rpc_socket, {"argv": ["--help"]})["exit_code"] == 0

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -19,7 +19,8 @@ import pytest
 from flask import g
 from flask.cli import ScriptInfo
 
-from invenio_app.cli import RPCServer, send_request
+from invenio_app.cli import cli
+from invenio_app.rpc import RPCServer, send_request
 
 
 @pytest.fixture()
@@ -31,7 +32,7 @@ def rpc_socket(base_app):
     """
     tmp_dir = tempfile.TemporaryDirectory(prefix="rpc", dir="/tmp")
     socket_path = Path(tmp_dir.name) / "rpc.sock"
-    server = RPCServer(socket_path, ScriptInfo(create_app=lambda: base_app))
+    server = RPCServer(socket_path, cli, ScriptInfo(create_app=lambda: base_app))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     yield socket_path

--- a/tests/test_rpc_server.py
+++ b/tests/test_rpc_server.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""RPC server tests."""
+
+import json
+import socket
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from invenio_app.cli import RPCServer, send_request
+
+
+@pytest.fixture()
+def rpc_socket():
+    """A running RPC server on a temporary socket.
+
+    Uses a short-lived directory under /tmp because AF_UNIX paths are
+    limited to ~104 bytes on macOS, which pytest's tmp_path exceeds.
+    """
+    tmp_dir = tempfile.TemporaryDirectory(prefix="rpc", dir="/tmp")
+    socket_path = Path(tmp_dir.name) / "rpc.sock"
+    server = RPCServer(socket_path)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield socket_path
+    server.shutdown()
+    server.server_close()
+    tmp_dir.cleanup()
+
+
+def test_ping(rpc_socket):
+    """The server answers a ping."""
+    assert send_request(rpc_socket, {"ping": True}) == {"pong": True}
+
+
+def test_request_larger_than_a_socket_buffer(rpc_socket):
+    """Requests are framed by line, not by a fixed read size."""
+    request = {"ping": True, "padding": "x" * 100_000}
+    assert send_request(rpc_socket, request) == {"pong": True}
+
+
+def test_invalid_json(rpc_socket):
+    """A malformed request gets an error response, not a hangup."""
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+        s.connect(str(rpc_socket))
+        s.sendall(b"not json\n")
+        with s.makefile("rb") as f:
+            response = json.loads(f.readline())
+    assert response["exit_code"] == 2
+    assert "not valid JSON" in response["stderr"]
+
+
+def test_argv_must_be_a_list_of_strings(rpc_socket):
+    """A non-argv payload is rejected."""
+    response = send_request(rpc_socket, {"argv": "collect"})
+    assert response["exit_code"] == 2
+    assert "list of strings" in response["stderr"]

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2020 CERN.
+# SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Test Jinja template loading."""
@@ -41,7 +42,7 @@ def blueprint():
 @pytest.fixture()
 def notheme_app(instance_path, blueprint):
     """Application without template theming."""
-    app = create_ui()
+    app = create_ui(SECRET_KEY="CHANGE_ME")
     app.register_blueprint(blueprint)
     with app.app_context():
         yield app
@@ -50,7 +51,10 @@ def notheme_app(instance_path, blueprint):
 @pytest.fixture()
 def theme_app(instance_path, blueprint):
     """Application with template theming."""
-    app = create_ui(APP_THEME=["semantic-ui", "bootstrap3"])
+    app = create_ui(
+        APP_THEME=["semantic-ui", "bootstrap3"],
+        SECRET_KEY="CHANGE_ME",
+    )
     app.register_blueprint(blueprint)
     with app.app_context():
         yield app


### PR DESCRIPTION
- **feat(cli): add RPCServer commands**
- **feat(ext): add config var for flask-debugtoolbar**
  * show the warning only if the toolbar is enabled. This makes it
    possible to turn it off on tests.
  * default is enabled to be backwards compatible
- **fix: turn off warning for RATELIMIT_STORAGE_URI**
  * Using the in-memory storage for tracking rate limits as no storage
    was explicitly specified. This is not recommended for production use.
    See: https://flask-limiter.readthedocs.io#configuring-a-storage-backend
    for documentation about configuring the storage backend.
- **fix: turn off warning SECRET_KEY**
  * Set configuration variable SECRET_KEY with random string

**refactor(rpc): switch to JSON lines over a Unix domain socket**
* Pickle over an unauthenticated TCP port let any local process run arbitrary code through deserialization, and the fixed-size `recv()` calls truncated any payload larger than one read.
* Requests are now one JSON line (`{"argv": [...]}`) over a Unix domain socket, so framing is `readline()`, authentication is file permissions, and the payload is the plain argv array the server routes into the click CLI anyway.
* The socket defaults to `<instance_path>/rpc.sock` (override with `--socket`), which isolates concurrent instances and removes the port collisions with the dev server.
* Responses carry exit_code, stdout and stderr; `rpc-server send` relays all three and exits with the server's exit code, so callers can detect failed commands.
* The standalone `rpc-server` console script is gone since clients can speak the protocol with stdlib socket+json.

**perf(rpc): reuse the app across requests and add a pid file**

* Each request used to build a fresh `ScriptInfo`, so `create_app()` ran for every command and the server only amortized imports. A single `ScriptInfo` now hands out the app created at startup, so commands after the first skip app creation entirely.
* Commands also run through click's standalone mode, which prints usage errors itself and produces the regular exit codes (a `--help` or usage error previously leaked SystemExit and tore down the connection without a response).
* The server now writes `<socket>.pid` for finding orphaned servers after a hard kill, removes socket and pid file on SIGTERM as well as Ctrl+C, and restricts the socket to the owning user (0600).

**feat(rpc): stream command output through passed file descriptors**

* A client can now attach its stdout/stderr (or a log file) to the request via SCM_RIGHTS over the Unix socket.
* The server swaps both the process-level descriptors 1/2 (so subprocess output such as webpack builds reaches the client live) and the Python-level sys.stdout/stderr (for click output) around the command, and the response shrinks to just the exit code.
* Requests without descriptors keep the captured-output response, which `rpc-server send` and programmatic callers still use.

**fix(rpc): isolate app context, SIGTERM, and fd restore per request**

* Commands now run inside a fresh app context pushed by the server.  Flask's `with_appcontext` skips pushing one when `current_app` is already set, which it always was because of the start command's own decorator, so `flask.g` and teardown handlers (notably the SQLAlchemy session removal) leaked across requests.
* SIGTERM now raises a dedicated `ServerStop(BaseException)` instead of SystemExit. A terminating signal landing mid-command was caught by the command's exit-code handling and the server kept running.
* In fd-redirected mode the server restores its own stdio before closing the client-bound streams. `close()` flushes and raises on a client-closed pipe, which previously skipped the restore and left fd 1/2 pointing at the dead client.
* Truncated SCM_RIGHTS data (more fds than the two expected) is now rejected instead of silently running with the first two.

**refactor(rpc): move the server machinery into its own module**

* `invenio_app/rpc.py` now holds the protocol and server plumbing (`recv_request`, `RPCRequestHandler`, `RPCServer`, `send_request`, `ServerStop`) with the click CLI injected into `RPCServer`, so the module depends on neither click nor flask.
* The `rpc-server` command group stays in `cli.py` next to the rest of the CLI. No behavior change.